### PR TITLE
Enhancement: pre-select current project

### DIFF
--- a/src/containers/header/projectMenu.jsx
+++ b/src/containers/header/projectMenu.jsx
@@ -3,9 +3,15 @@ import { Button } from 'openpype-components'
 
 import { Sidebar } from 'primereact/sidebar'
 import ProjectList from '/src/containers/projectList'
+import { useSelector } from 'react-redux'
 
 const ProjectMenu = ({ visible, onHide }) => {
   const navigate = useNavigate()
+
+  // get project context
+  const context = useSelector((state) => ({ ...state.context }))
+  // get current project name (id)
+  const projectName = context.projectName
 
   const footer = (
     <Button
@@ -37,6 +43,7 @@ const ProjectMenu = ({ visible, onHide }) => {
           onSelect={(projectName) =>
             navigate(`/projects/${projectName}/browser`)
           }
+          selection={projectName}
         />
       </div>
     </Sidebar>


### PR DESCRIPTION
### Brief Description
Pre-selects the current project when changing between projects in projectMenu sidebar.

### Description
`projectMenu` gets current `projectName`  from redux state and then sets `projectList` prop `selection=projectName`. The project name is pre-selected. An "un-selectable" option probably isn't needed as selecting an already selected project does nothing. 

<img width="621" alt="image" src="https://user-images.githubusercontent.com/49156310/207046255-10e92eff-f94f-4b4e-bbd2-bdda59c57630.png">
