### PR TITLE
Fix toast z-index to be higher than dialog

### DIFF
--- a/src/styles/index.sass
+++ b/src/styles/index.sass
@@ -1,5 +1,6 @@
 #root
-  position: fixed
+  position: absolute
+  overflow: hidden
   top: 0
   left: 0
   right: 0


### PR DESCRIPTION
### Brief Description

`position: fixed;` on `body` parent of `Toast` was causing some weird z-index issues as the `Dialog` was outside of `body`. Changing to `position: absolute` fixed z-index behaviour.