### PR TITLE
Feature/op 4168 tags colors search artist tags

### DIFF
--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -92,7 +92,7 @@ const Hierarchy = (props) => {
   const projectName = context.projectName
   const folderTypes = context.project.folderTypes
   const expandedFolders = context.expandedFolders
-  const focusedFolders = context.focusedFolders
+  const focusedFolders = context.focused.folders
 
   const dispatch = useDispatch()
   const [query, setQuery] = useState('')
@@ -218,8 +218,6 @@ const Hierarchy = (props) => {
         dispatch(
           setDialog({
             type: 'tags',
-            entityIds: focusedFolders,
-            entityType: 'folder',
           })
         ),
       disabled: focusedFolders.length !== 1,

--- a/src/containers/tagsEditor/dialog.jsx
+++ b/src/containers/tagsEditor/dialog.jsx
@@ -12,7 +12,6 @@ const TagsEditorDialog = ({
   tags,
   isLoading,
   isError,
-  names,
 }) => {
   // temp dialog
   const dialogRef = useRef(null)
@@ -61,7 +60,7 @@ const TagsEditorDialog = ({
 
   const header = (
     <div>
-      <h2>{`Editing Tags: ${names[0]}`}</h2>
+      <h2>Tags Editor</h2>
     </div>
   )
 
@@ -97,7 +96,6 @@ TagsEditorDialog.propTypes = {
   value: PropTypes.arrayOf(PropTypes.string),
   tags: tagsType,
   isLoading: PropTypes.bool,
-  names: PropTypes.string,
 }
 
 export default TagsEditorDialog

--- a/src/containers/tagsEditor/dialog.jsx
+++ b/src/containers/tagsEditor/dialog.jsx
@@ -12,6 +12,7 @@ const TagsEditorDialog = ({
   tags,
   isLoading,
   isError,
+  names,
 }) => {
   // temp dialog
   const dialogRef = useRef(null)
@@ -52,7 +53,7 @@ const TagsEditorDialog = ({
   }
 
   const footer = (
-    <div style={{ display: 'flex', gap: '20px' }}>
+    <div style={{ display: 'flex', gap: '10px', justifyContent: 'center' }}>
       <Button label={'Cancel'} onClick={handleCancel} />
       <Button label={'Save'} onClick={handleSuccess} />
     </div>
@@ -60,7 +61,7 @@ const TagsEditorDialog = ({
 
   const header = (
     <div>
-      <h2>Tags Editor</h2>
+      <h2>{`Editing Tags: ${names[0]}`}</h2>
     </div>
   )
 
@@ -96,6 +97,7 @@ TagsEditorDialog.propTypes = {
   value: PropTypes.arrayOf(PropTypes.string),
   tags: tagsType,
   isLoading: PropTypes.bool,
+  names: PropTypes.string,
 }
 
 export default TagsEditorDialog

--- a/src/containers/tagsEditor/editor.jsx
+++ b/src/containers/tagsEditor/editor.jsx
@@ -59,7 +59,7 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
   return (
     <EditorContainer>
       <div>
-        <h3>Selected</h3>
+        <h3>Assigned</h3>
         <ButtonsContainer>
           {value.map((v) => (
             <Button
@@ -67,13 +67,13 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
               icon="close"
               onClick={() => handleRemove(v)}
               key={v}
-              style={{ backgroundColor: '#435648' }}
+              style={{ backgroundColor: '#435648', gap: 3 }}
             />
           ))}
         </ButtonsContainer>
       </div>
       <div>
-        <h3>Tags</h3>
+        <h3>Available</h3>
         <ButtonsContainer>
           {options.map(
             ({ name }) =>
@@ -83,6 +83,7 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
                   icon="add"
                   onClick={() => handleAdd(name)}
                   key={name}
+                  style={{ gap: 3 }}
                 />
               )
           )}

--- a/src/containers/tagsEditor/editor.jsx
+++ b/src/containers/tagsEditor/editor.jsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import { Button } from 'openpype-components'
+import { Button, InputText } from 'openpype-components'
 import styled from 'styled-components'
 
 const EditorContainer = styled.div`
@@ -19,9 +19,18 @@ const ButtonsContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
+  margin-top: 10px;
+`
+
+const AvailableHeader = styled.header`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `
 
 const TagsEditor = ({ options = [], value = [], onChange }) => {
+  const [search, setSearch] = useState('')
+
   const handleRemove = (v) => {
     console.log('removing:', v)
     const newValue = [...value]
@@ -56,6 +65,15 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
     }
   }
 
+  // filter out already selected options
+  let filteredOptions = options.filter(({ name }) => !value.includes(name))
+  if (search !== '') {
+    // filter results if searched
+    filteredOptions = filteredOptions.filter(({ name }) =>
+      name.includes(search)
+    )
+  }
+
   return (
     <EditorContainer>
       <div>
@@ -73,20 +91,25 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
         </ButtonsContainer>
       </div>
       <div>
-        <h3>Available</h3>
+        <AvailableHeader>
+          <h3>Available</h3>
+          <InputText
+            placeholder={'Search tags...'}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </AvailableHeader>
+
         <ButtonsContainer>
-          {options.map(
-            ({ name }) =>
-              !value.includes(name) && (
-                <Button
-                  label={name}
-                  icon="add"
-                  onClick={() => handleAdd(name)}
-                  key={name}
-                  style={{ gap: 3 }}
-                />
-              )
-          )}
+          {filteredOptions.map(({ name }) => (
+            <Button
+              label={name}
+              icon="add"
+              onClick={() => handleAdd(name)}
+              key={name}
+              style={{ gap: 3 }}
+            />
+          ))}
         </ButtonsContainer>
       </div>
     </EditorContainer>

--- a/src/containers/tagsEditor/editor.jsx
+++ b/src/containers/tagsEditor/editor.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { Button, InputText } from 'openpype-components'
 import styled from 'styled-components'
@@ -74,20 +74,31 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
     )
   }
 
+  const optionsObject = useMemo(
+    () => options.reduce((acc, cur) => ({ ...acc, [cur.name]: cur }), {}),
+    [options]
+  )
+
   return (
     <EditorContainer>
       <div>
         <h3>Assigned</h3>
         <ButtonsContainer>
-          {value.map((v) => (
-            <Button
-              label={v}
-              icon="close"
-              onClick={() => handleRemove(v)}
-              key={v}
-              style={{ backgroundColor: '#435648', gap: 3 }}
-            />
-          ))}
+          {value.map((v) => {
+            const value = optionsObject[v]
+            return (
+              <Button
+                label={v}
+                icon="close"
+                onClick={() => handleRemove(v)}
+                key={v}
+                style={{
+                  gap: 3,
+                  borderLeft: `solid 4px ${value.color}`,
+                }}
+              />
+            )
+          })}
         </ButtonsContainer>
       </div>
       <div>
@@ -99,15 +110,17 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
             onChange={(e) => setSearch(e.target.value)}
           />
         </AvailableHeader>
-
         <ButtonsContainer>
-          {filteredOptions.map(({ name }) => (
+          {filteredOptions.map(({ name, color }) => (
             <Button
               label={name}
               icon="add"
               onClick={() => handleAdd(name)}
               key={name}
-              style={{ gap: 3 }}
+              style={{
+                gap: 3,
+                borderLeft: `solid 4px ${color}`,
+              }}
             />
           ))}
         </ButtonsContainer>

--- a/src/containers/tagsEditor/index.jsx
+++ b/src/containers/tagsEditor/index.jsx
@@ -18,6 +18,7 @@ export const TagsEditorContainer = ({
   const [isLoading, setIsLoading] = useState(false)
   const [isError, setIsError] = useState(false)
   const [tags, setTags] = useState([])
+  const [names, setNames] = useState([])
 
   useEffect(() => {
     if (ids && type) {
@@ -30,7 +31,9 @@ export const TagsEditorContainer = ({
             `/api/projects/${projectName}/${type}s/${ids[0]}`
           )
 
+          console.log(data)
           setTags(data.tags)
+          setNames([data.name])
           console.log(data)
         } catch (error) {
           console.error(error)
@@ -75,6 +78,7 @@ export const TagsEditorContainer = ({
       onSuccess={handleSuccess}
       isLoading={isLoading}
       isError={isError}
+      names={names}
     />
   )
 }

--- a/src/containers/tagsEditor/index.jsx
+++ b/src/containers/tagsEditor/index.jsx
@@ -1,43 +1,37 @@
 import React, { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { setDialog } from '/src/features/context'
 import TagsEditorDialog from './dialog'
 import axios from 'axios'
 import { toast } from 'react-toastify'
 import { setReload } from '../../features/context'
 
-export const TagsEditorContainer = () => {
+export const TagsEditorContainer = ({
+  ids,
+  type,
+  projectName,
+  projectTags,
+}) => {
   // get redux context state
   const dispatch = useDispatch()
-  const context = useSelector((state) => ({ ...state.context }))
-  // check if tags dialog is open
-  const isTagsOpen = context.dialog.type === 'tags'
 
-  const entityType = context.dialog.entityType
-  const entityIds = context.dialog.entityIds
-  // start off with only being able to edit one entities set of tags
-  const entityId = entityIds && entityIds.length ? entityIds[0] : null
-  const projectName = context.projectName
-  // get all tags for project
-  const projectTags = context.project.tags
-
-  //   DUMMY TAGS STATE
   const [isLoading, setIsLoading] = useState(false)
   const [isError, setIsError] = useState(false)
   const [tags, setTags] = useState([])
 
   useEffect(() => {
-    if (isTagsOpen && entityId) {
+    if (ids && type) {
       // get tags for entity
       setIsLoading(true)
 
       const getTags = async () => {
         try {
           const { data } = await axios.get(
-            `/api/projects/${projectName}/${entityType}s/${entityId}`
+            `/api/projects/${projectName}/${type}s/${ids[0]}`
           )
 
           setTags(data.tags)
+          console.log(data)
         } catch (error) {
           console.error(error)
           const errMessage =
@@ -51,18 +45,17 @@ export const TagsEditorContainer = () => {
 
       getTags()
     }
-  }, [isTagsOpen, entityId, setIsLoading])
+  }, [ids, setIsLoading])
 
   const handleSuccess = async (tags) => {
     console.log(tags)
     try {
-      await axios.patch(
-        `/api/projects/${projectName}/${entityType}s/${entityId}`,
-        { tags }
-      )
+      await axios.patch(`/api/projects/${projectName}/${type}s/${ids[0]}`, {
+        tags,
+      })
 
       // on success updating tags dispatch reload of data
-      dispatch(setReload({ type: entityType, reload: true }))
+      dispatch(setReload({ type: type, reload: true }))
 
       // dispatch callback function to reload data
     } catch (error) {
@@ -75,7 +68,7 @@ export const TagsEditorContainer = () => {
 
   return (
     <TagsEditorDialog
-      visible={isTagsOpen}
+      visible={true}
       onHide={() => dispatch(setDialog())}
       tags={projectTags}
       value={tags}

--- a/src/containers/taskList.jsx
+++ b/src/containers/taskList.jsx
@@ -37,7 +37,8 @@ const TaskList = ({ style = {} }) => {
   const dispatch = useDispatch()
   const context = useSelector((state) => ({ ...state.context }))
   const projectName = context.projectName
-  const folderIds = context.focusedFolders
+  const folderIds = context.focused.folders
+  const focusedTasks = context.focused.tasks
 
   const [data, setData] = useState([])
   const [loading, setLoading] = useState(false)
@@ -87,9 +88,9 @@ const TaskList = ({ style = {} }) => {
 
   const selectedTasks = useMemo(() => {
     const r = {}
-    for (const tid of context.focusedTasks) r[tid] = true
+    for (const tid of focusedTasks) r[tid] = true
     return r
-  }, [context.focusedTasks])
+  }, [focusedTasks])
 
   //
   // Handlers
@@ -108,7 +109,7 @@ const TaskList = ({ style = {} }) => {
   }
 
   const onContextMenuSelectionChange = (event) => {
-    if (context.focusedTasks.includes(event.value)) return
+    if (focusedTasks.includes(event.value)) return
     dispatch(setPairing([{ taskId: event.value }]))
     dispatch(setFocusedTasks([event.value]))
   }
@@ -144,7 +145,7 @@ const TaskList = ({ style = {} }) => {
     {
       label: 'Detail',
       command: () => setShowDetail(true),
-      disabled: context.focusedTasks.length !== 1,
+      disabled: focusedTasks.length !== 1,
     },
     {
       label: 'Edit Tags',
@@ -152,11 +153,9 @@ const TaskList = ({ style = {} }) => {
         dispatch(
           setDialog({
             type: 'tags',
-            entityIds: context.focusedTasks,
-            entityType: 'task',
           })
         ),
-      disabled: context.focusedFolders.length !== 1,
+      disabled: context.focused.folders.length !== 1,
     },
   ]
 
@@ -167,7 +166,7 @@ const TaskList = ({ style = {} }) => {
         <EntityDetail
           projectName={projectName}
           entityType="task"
-          entityId={context.focusedTasks[0]}
+          entityId={focusedTasks[0]}
           visible={showDetail}
           onHide={() => setShowDetail(false)}
         />

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -6,10 +6,13 @@ const contextSlice = createSlice({
     projectName: null,
     project: {},
     expandedFolders: {},
-    focusedType: null,
-    focusedFolders: [],
-    focusedSubsets: [],
-    focusedVersions: [],
+    focused: {
+      type: null,
+      folders: [],
+      subsets: [],
+      versions: [],
+      tasks: [],
+    },
     focusedTasks: [],
     selectedVersions: {},
     pairing: [],
@@ -33,45 +36,44 @@ const contextSlice = createSlice({
     },
 
     setFocusedFolders: (state, action) => {
-      state.focusedType = 'folder'
-      state.focusedFolders = action.payload
-      state.focusedSubsets = []
-      state.focusedVersions = []
+      state.focused.type = 'folder'
+      state.focused.folders = action.payload
+      state.focused.subsets = []
+      state.focused.versions = []
       state.pairing = []
     },
 
     setFocusedSubsets: (state, action) => {
-      state.focusedType = 'subset'
-      state.focusedSubsets = action.payload
-      state.focusedVersions = []
+      state.focused.type = 'subset'
+      state.focused.subsets = action.payload
+      state.focused.versions = []
     },
 
     setFocusedTasks: (state, action) => {
-      state.focusedType = 'task'
+      state.focused.type = 'task'
       state.focusedTasks = action.payload
-      state.focusedVersions = []
+      state.focused.versions = []
     },
 
     setFocusedVersions: (state, action) => {
       if (action.payload === null) {
-        state.focusedType = 'folder'
-        state.focusedVersions = []
+        state.focused.type = 'folder'
+        state.focused.versions = []
       } else {
-        state.focusedType = 'version'
-        state.focusedVersions = action.payload
+        state.focused.type = 'version'
+        state.focused.versions = action.payload
         state.focusedTasks = []
       }
     },
-
     setSelectedVersions: (state, action) => {
       state.selectedVersions = action.payload
     },
 
     clearFocus: (state, action) => {
-      state.focusedType = null
-      state.focusedFolders = []
-      state.focusedSubsets = []
-      state.focusedVersions = []
+      state.focused.type = null
+      state.focused.folders = []
+      state.focused.subsets = []
+      state.focused.versions = []
     },
 
     setPairing: (state, action) => {

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -13,7 +13,6 @@ const contextSlice = createSlice({
       versions: [],
       tasks: [],
     },
-    focusedTasks: [],
     selectedVersions: {},
     pairing: [],
     dialog: {},
@@ -51,7 +50,7 @@ const contextSlice = createSlice({
 
     setFocusedTasks: (state, action) => {
       state.focused.type = 'task'
-      state.focusedTasks = action.payload
+      state.focused.tasks = action.payload
       state.focused.versions = []
     },
 
@@ -62,7 +61,7 @@ const contextSlice = createSlice({
       } else {
         state.focused.type = 'version'
         state.focused.versions = action.payload
-        state.focusedTasks = []
+        state.focused.tasks = []
       }
     },
     setSelectedVersions: (state, action) => {

--- a/src/pages/browser/detail.jsx
+++ b/src/pages/browser/detail.jsx
@@ -10,7 +10,7 @@ const Detail = () => {
 
   let detailComponent = null
 
-  switch (context.focusedType) {
+  switch (context.focused.type) {
     case 'folder':
       detailComponent = <FolderDetail />
       break
@@ -24,8 +24,9 @@ const Detail = () => {
       break
   }
 
-  const header = context.focusedType
-    ? context.focusedType.charAt(0).toUpperCase() + context.focusedType.slice(1)
+  const header = context.focused.type
+    ? context.focused.type.charAt(0).toUpperCase() +
+      context.focused.type.slice(1)
     : 'No selection'
 
   return (

--- a/src/pages/browser/folderDetail.jsx
+++ b/src/pages/browser/folderDetail.jsx
@@ -47,7 +47,7 @@ const FolderDetail = () => {
   const dispatch = useDispatch()
   const context = useSelector((state) => ({ ...state.context }))
   const projectName = context.projectName
-  const folders = context.focusedFolders
+  const folders = context.focused.folders
   const folderId = folders.length === 1 ? folders[0] : null
 
   const [data, setData] = useState({})

--- a/src/pages/browser/index.jsx
+++ b/src/pages/browser/index.jsx
@@ -1,5 +1,6 @@
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 import { Section } from 'openpype-components'
+import { useSelector } from 'react-redux'
 
 import Hierarchy from '/src/containers/hierarchy'
 import TaskList from '/src/containers/taskList'
@@ -9,6 +10,18 @@ import Detail from './detail'
 import TagsEditorContainer from '/src/containers/tagsEditor'
 
 const BrowserPage = () => {
+  const context = useSelector((state) => ({ ...state.context }))
+  // check if tags dialog is open
+  const dialogType = context.dialog.type
+  const projectName = context.projectName
+  // get all tags for project
+  const projectTags = context.project.tags
+  const focusedType = context.focused.type
+  let focusedIds = []
+  if (focusedType) {
+    focusedIds = context.focused[`${focusedType}s`]
+  }
+
   return (
     <main>
       <Splitter layout="horizontal" style={{ width: '100%', height: '100%' }}>
@@ -30,7 +43,13 @@ const BrowserPage = () => {
           </Splitter>
         </SplitterPanel>
       </Splitter>
-      <TagsEditorContainer />
+      {dialogType === 'tags' && !!focusedIds?.length && (
+        <TagsEditorContainer
+          ids={focusedIds}
+          type={focusedType}
+          {...{ projectName, projectTags }}
+        />
+      )}
     </main>
   )
 }

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -32,10 +32,10 @@ const Subsets = () => {
   const context = useSelector((state) => ({ ...state.context }))
 
   const projectName = context.projectName
-  const focusedVersions = context.focusedVersions
-  const focusedFolders = context.focusedFolders
+  const focusedVersions = context.focused.versions
+  const focusedFolders = context.focused.folders
   const selectedVersions = context.selectedVersions
-  const focusedSubsets = context.focusedSubsets
+  const focusedSubsets = context.focused.subsets
   const pairing = context.pairing
 
   const [subsetData, setSubsetData] = useState([])
@@ -287,8 +287,6 @@ const Subsets = () => {
         dispatch(
           setDialog({
             type: 'tags',
-            entityIds: focusedVersions,
-            entityType: 'version',
           })
         ),
       disabled: focusedVersions.length !== 1,

--- a/src/pages/browser/taskDetail.jsx
+++ b/src/pages/browser/taskDetail.jsx
@@ -44,7 +44,7 @@ const TaskDetail = () => {
   const dispatch = useDispatch()
   const context = useSelector((state) => ({ ...state.context }))
   const projectName = context.projectName
-  const tasks = context.focusedTasks
+  const tasks = context.focused.tasks
   const taskId = tasks.length === 1 ? tasks[0] : null
   const [data, setData] = useState({})
   const query = buildTaskQuery()

--- a/src/pages/browser/versionDetail.jsx
+++ b/src/pages/browser/versionDetail.jsx
@@ -70,8 +70,10 @@ const VersionDetail = () => {
 
   const query = buildVersionQuery()
 
+  const focusedVersions = context.focused.versions
+
   const getVersionData = () => {
-    if (!(context.focusedVersions && context.focusedVersions.length)) {
+    if (!focusedVersions?.length) {
       setVersions([])
       setRepresentations([])
       return
@@ -80,7 +82,7 @@ const VersionDetail = () => {
     axios
       .post('/graphql', {
         query: query,
-        variables: { projectName, versions: context.focusedVersions },
+        variables: { projectName, versions: focusedVersions },
       })
       .then((response) => {
         const data = response.data.data
@@ -133,7 +135,7 @@ const VersionDetail = () => {
   useEffect(() => {
     getVersionData()
     //eslint-disable-next-line
-  }, [context.projectName, context.focusedVersions, projectName])
+  }, [context.projectName, focusedVersions, projectName])
 
   const reload = context.reload.version
 

--- a/src/pages/editor/index.jsx
+++ b/src/pages/editor/index.jsx
@@ -52,10 +52,10 @@ const EditorPage = () => {
     // so it is compatible with the treetable selection argument and it
     // also provides complete node information
     const result = {}
-    for (const key of context.focusedFolders) result[key] = nodeData[key]
-    for (const key of context.focusedTasks) result[key] = nodeData[key]
+    for (const key of context.focused.folders) result[key] = nodeData[key]
+    for (const key of context.focused.tasks) result[key] = nodeData[key]
     return result
-  }, [context.focusedFolders, context.focusedTasks, nodeData])
+  }, [context.focused.folders, context.focused.tasks, nodeData])
 
   //
   // Helpers
@@ -221,7 +221,7 @@ const EditorPage = () => {
     })
 
     // Force table render when selection is locked
-    if (selectionLocked) dispatch(setFocusedFolders(context.focusedFolders))
+    if (selectionLocked) dispatch(setFocusedFolders(context.focused.folders))
   }
 
   const updateName = (options, value) => {
@@ -713,7 +713,12 @@ const EditorPage = () => {
                     return col.editor(
                       options,
                       updateAttribute,
-                      formatAttribute(options.rowData, changes, col.name, false),
+                      formatAttribute(
+                        options.rowData,
+                        changes,
+                        col.name,
+                        false
+                      ),
                       col.editorSettings
                     )
                   }}

--- a/src/pages/projectAddon.jsx
+++ b/src/pages/projectAddon.jsx
@@ -17,7 +17,7 @@ const ProjectAddon = ({ addonName, addonVersion, sidebar }) => {
   const [loading, setLoading] = useState(true)
 
   const context = useSelector((state) => ({ ...state.context }))
-  const focusedFolders = context.focusedFolders
+  const focusedFolders = context.focused.folders
 
   const addonUrl = `${window.location.origin}/addons/${addonName}/${addonVersion}/frontend/`
 
@@ -39,9 +39,7 @@ const ProjectAddon = ({ addonName, addonVersion, sidebar }) => {
 
   const sidebarComponent = useMemo(() => {
     if (sidebar === 'hierarchy') {
-      return (
-        <Hierarchy style={{ maxWidth: 500, minWidth: 300 }} />
-      )
+      return <Hierarchy style={{ maxWidth: 500, minWidth: 300 }} />
     } else {
       return <></>
     }

--- a/src/pages/workfiles/index.jsx
+++ b/src/pages/workfiles/index.jsx
@@ -67,7 +67,9 @@ const WorkfileDetail = ({ projectName, workfileId, style }) => {
         <AttributeTable
           entityType="workfile"
           data={data?.attrib || {}}
-          additionalData={[{ title: 'Path', value: <PathField value={data?.path}/> }]}
+          additionalData={[
+            { title: 'Path', value: <PathField value={data?.path} /> },
+          ]}
         />
       </Panel>
     </Section>
@@ -169,7 +171,7 @@ const WorkfilesPage = () => {
 
   const context = useSelector((state) => ({ ...state.context }))
   const projectName = context.projectName
-  const focusedTasks = context.focusedTasks
+  const focusedTasks = context.focused.tasks
   const pairing = context.pairing
 
   return (


### PR DESCRIPTION
### Brief Description

Display the colors of the tags and have a basic search to quickly find specific tags.

### Description

- Changed redux focussed states from `focusedFolders -> focused.folders`
- Use `type = focused.type` and  `ids = focused[type]` in redux instead of passing them through the dialog redux state.
- Search uses a basic `names.includes(search)` to filter matching names.
- Tag colors are basic but need some work.

![image](https://user-images.githubusercontent.com/49156310/208855291-e4460d1b-1ace-40b3-a313-4b5f14280858.png)

