### PR TITLE
Enhancement: Add "artist" new tags

### DIFF
--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -197,7 +197,7 @@ const Hierarchy = (props) => {
         dispatch(
           setDialog({
             type: 'tags',
-          })
+          }),
         ),
       disabled: focusedFolders.length !== 1,
     },

--- a/src/containers/tagsEditor/createButton.jsx
+++ b/src/containers/tagsEditor/createButton.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, InputText } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+
+const FormStyled = styled.form`
+  display: flex;
+
+  button {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  input {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+`
+
+const CreateButton = ({
+  icon = 'add',
+  placeholder = 'New item...',
+  value,
+  onChange,
+  onSubmit,
+  noSpaces,
+}) => {
+  const pattern = noSpaces ? '^\\S+$' : ''
+
+  return (
+    <FormStyled onSubmit={onSubmit}>
+      <Button icon={icon} />
+      <InputText placeholder={placeholder} value={value} onChange={onChange} pattern={pattern} />
+    </FormStyled>
+  )
+}
+
+CreateButton.propTypes = {
+  icon: PropTypes.string,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  onSubmit: PropTypes.func,
+}
+
+export default CreateButton

--- a/src/containers/tagsEditor/dialog.jsx
+++ b/src/containers/tagsEditor/dialog.jsx
@@ -65,7 +65,7 @@ const TagsEditorDialog = ({ visible, onHide, onSuccess, value, tags, isLoading, 
       footer={footer}
       header={header}
       ref={dialogRef}
-      onShow={() => setHeight(dialogRef.current?.getElement()?.offsetHeight)}
+      onShow={() => setHeight(dialogRef.current?.getElement()?.offsetHeight + 15)}
       style={{ height: height || 'unset' }}
       contentStyle={{ overflow: 'hidden' }}
     >

--- a/src/containers/taskList.jsx
+++ b/src/containers/taskList.jsx
@@ -145,7 +145,7 @@ const TaskList = ({ style = {} }) => {
         dispatch(
           setDialog({
             type: 'tags',
-          })
+          }),
         ),
       disabled: context.focused.folders.length !== 1,
     },


### PR DESCRIPTION
### Brief Description

Create new tags without leaving the tags editor dialog. These tags aren't set globally and are set locally for that entity.

### Description

- Could do with a better way of distinguishing between "gobal" and "artist" (local) tags.
- Maybe this would be better as an Addon?
- Artist tags currently have no color assigned to them. 

![image](https://user-images.githubusercontent.com/49156310/208903701-13d4b54c-a324-42cb-9544-550a904a7f6c.png)
 