### PR TITLE
Enhancement: multi entity tag support

### DIFF
--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -199,7 +199,6 @@ const Hierarchy = (props) => {
             type: 'tags',
           }),
         ),
-      disabled: focusedFolders.length !== 1,
     },
   ]
 

--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -197,7 +197,7 @@ const Hierarchy = (props) => {
         dispatch(
           setDialog({
             type: 'tags',
-          })
+          }),
         ),
       disabled: focusedFolders.length !== 1,
     },

--- a/src/containers/tagsEditor/createButton.jsx
+++ b/src/containers/tagsEditor/createButton.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, InputText } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+
+const FormStyled = styled.form`
+  display: flex;
+
+  button {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  input {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+`
+
+const CreateButton = ({
+  icon = 'add',
+  placeholder = 'New item...',
+  value,
+  onChange,
+  onSubmit,
+  noSpaces,
+}) => {
+  const pattern = noSpaces ? '^\\S+$' : ''
+
+  return (
+    <FormStyled onSubmit={onSubmit}>
+      <Button icon={icon} />
+      <InputText placeholder={placeholder} value={value} onChange={onChange} pattern={pattern} />
+    </FormStyled>
+  )
+}
+
+CreateButton.propTypes = {
+  icon: PropTypes.string,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  onSubmit: PropTypes.func,
+}
+
+export default CreateButton

--- a/src/containers/tagsEditor/dialog.jsx
+++ b/src/containers/tagsEditor/dialog.jsx
@@ -65,7 +65,7 @@ const TagsEditorDialog = ({ visible, onHide, onSuccess, value, tags, isLoading, 
       footer={footer}
       header={header}
       ref={dialogRef}
-      onShow={() => setHeight(dialogRef.current?.getElement()?.offsetHeight)}
+      onShow={() => setHeight(dialogRef.current?.getElement()?.offsetHeight + 15)}
       style={{ height: height || 'unset' }}
       contentStyle={{ overflow: 'hidden' }}
     >

--- a/src/containers/tagsEditor/index.jsx
+++ b/src/containers/tagsEditor/index.jsx
@@ -6,19 +6,13 @@ import axios from 'axios'
 import { toast } from 'react-toastify'
 import { setReload } from '../../features/context'
 
-export const TagsEditorContainer = ({
-  ids,
-  type,
-  projectName,
-  projectTags,
-}) => {
+export const TagsEditorContainer = ({ ids, type, projectName, projectTags }) => {
   // get redux context state
   const dispatch = useDispatch()
 
   const [isLoading, setIsLoading] = useState(false)
   const [isError, setIsError] = useState(false)
   const [tags, setTags] = useState([])
-  const [names, setNames] = useState([])
 
   useEffect(() => {
     if (ids && type) {
@@ -27,13 +21,10 @@ export const TagsEditorContainer = ({
 
       const getTags = async () => {
         try {
-          const { data } = await axios.get(
-            `/api/projects/${projectName}/${type}s/${ids[0]}`
-          )
+          const { data } = await axios.get(`/api/projects/${projectName}/${type}s/${ids[0]}`)
 
           console.log(data)
           setTags(data.tags)
-          setNames([data.name])
           console.log(data)
         } catch (error) {
           console.error(error)
@@ -76,7 +67,6 @@ export const TagsEditorContainer = ({
       onSuccess={handleSuccess}
       isLoading={isLoading}
       isError={isError}
-      names={names}
     />
   )
 }

--- a/src/containers/taskList.jsx
+++ b/src/containers/taskList.jsx
@@ -145,7 +145,7 @@ const TaskList = ({ style = {} }) => {
         dispatch(
           setDialog({
             type: 'tags',
-          })
+          }),
         ),
       disabled: context.focused.folders.length !== 1,
     },

--- a/src/containers/taskList.jsx
+++ b/src/containers/taskList.jsx
@@ -147,7 +147,6 @@ const TaskList = ({ style = {} }) => {
             type: 'tags',
           }),
         ),
-      disabled: context.focused.folders.length !== 1,
     },
   ]
 

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -277,9 +277,8 @@ const Subsets = () => {
         dispatch(
           setDialog({
             type: 'tags',
-          })
+          }),
         ),
-      disabled: focusedVersions.length !== 1,
     },
   ]
 


### PR DESCRIPTION
### Brief Description

Allow the user to edit the tags of multiple entities at once.

### Description

- Currently all tags overwrite the previous tags for all entities selected.
- Warnings have been added so the user understands the risks of overwriting tags
- Future/Addon could allow the user to choose this overwriting behaviour (would require more advanced UI and a logic rewrite).
- Bugs: List of version names shows version names (v004, v004, v002) which isn't helpful.

![image](https://user-images.githubusercontent.com/49156310/208938236-28118b0e-b60d-4eee-9161-5e1d2d9adfe7.png)

  