### PR TITLE
Fix: width and height changing

### DIFF
--- a/src/containers/tagsEditor/editor.jsx
+++ b/src/containers/tagsEditor/editor.jsx
@@ -6,14 +6,14 @@ import CreateButton from './createButton'
 
 const EditorContainerStyled = styled.div`
   max-width: 400px;
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 20px;
 
-  &::after {
-    content: '';
-    height: 30px;
-  }
+  /* enable scrolling om avaible section */
+  overflow-y: hidden;
+  height: 100%;
 `
 
 const ButtonsContainerStyled = styled.div`
@@ -21,11 +21,19 @@ const ButtonsContainerStyled = styled.div`
   flex-wrap: wrap;
   gap: 5px;
   margin-top: 10px;
+  min-height: 65px;
 
   /* form fills whole row to push artist tags to a new line */
   form {
     flex-basis: 100%;
+    align-self: flex-end;
   }
+`
+
+// wraps avaiable header and buttons
+const SectionsWrapperStyled = styled.div`
+  /* scrolling for overflow */
+  overflow-y: auto;
 `
 
 const AvailableHeaderStyled = styled.header`
@@ -103,7 +111,7 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
 
   return (
     <EditorContainerStyled>
-      <div>
+      <SectionsWrapperStyled>
         <h3>Assigned</h3>
         <ButtonsContainerStyled>
           {[...globalTags, ...artistTags].map((v) => {
@@ -133,8 +141,8 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
             onChange={(e) => setNewItem(e.target.value)}
           />
         </ButtonsContainerStyled>
-      </div>
-      <div>
+      </SectionsWrapperStyled>
+      <SectionsWrapperStyled>
         <AvailableHeaderStyled>
           <h3>Available</h3>
           <InputText
@@ -157,7 +165,7 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
             />
           ))}
         </ButtonsContainerStyled>
-      </div>
+      </SectionsWrapperStyled>
     </EditorContainerStyled>
   )
 }

--- a/src/containers/tagsEditor/editor.jsx
+++ b/src/containers/tagsEditor/editor.jsx
@@ -152,18 +152,20 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
           />
         </AvailableHeaderStyled>
         <ButtonsContainerStyled>
-          {filteredOptions.map(({ name, color }) => (
-            <Button
-              label={name}
-              icon="add"
-              onClick={() => handleAdd(name)}
-              key={name}
-              style={{
-                gap: 3,
-                borderLeft: `solid 4px ${color}`,
-              }}
-            />
-          ))}
+          {filteredOptions.length
+            ? filteredOptions.map(({ name, color }) => (
+                <Button
+                  label={name}
+                  icon="add"
+                  onClick={() => handleAdd(name)}
+                  key={name}
+                  style={{
+                    gap: 3,
+                    borderLeft: `solid 4px ${color}`,
+                  }}
+                />
+              ))
+            : 'No results found in search...'}
         </ButtonsContainerStyled>
       </SectionsWrapperStyled>
     </EditorContainerStyled>

--- a/src/containers/tagsEditor/editor.jsx
+++ b/src/containers/tagsEditor/editor.jsx
@@ -111,7 +111,7 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
 
   return (
     <EditorContainerStyled>
-      <SectionsWrapperStyled>
+      <div>
         <h3>Assigned</h3>
         <ButtonsContainerStyled>
           {[...globalTags, ...artistTags].map((v) => {
@@ -141,7 +141,7 @@ const TagsEditor = ({ options = [], value = [], onChange }) => {
             onChange={(e) => setNewItem(e.target.value)}
           />
         </ButtonsContainerStyled>
-      </SectionsWrapperStyled>
+      </div>
       <SectionsWrapperStyled>
         <AvailableHeaderStyled>
           <h3>Available</h3>

--- a/src/containers/tagsEditor/editor.jsx
+++ b/src/containers/tagsEditor/editor.jsx
@@ -6,7 +6,7 @@ import CreateButton from './createButton'
 
 const EditorContainerStyled = styled.div`
   max-width: 400px;
-  width: 100%;
+  width: 90vw;
   display: flex;
   flex-direction: column;
   gap: 20px;


### PR DESCRIPTION
### Brief Description

Fixes a bug where the width of the dialog could change size when searching for tags. Now the width stays fixed.

### Description

- Width stays fixed when searching
- Available becomes scrollable when the height is overflown.
- When no tags are assigned the height doesn't change.
- Show a message when no search results match

### Testing

- Search for tags so that none match, the width should stay the same width.
- Create lots of new tags so that the height overflows and Available becomes scrollable.

![tags_editor_width_height_fixes](https://user-images.githubusercontent.com/49156310/209788167-0d62ce9a-b81a-4b3d-aa4d-5c38be3f3b54.gif)
