### PR TITLE
Feature: Status Select Dropdown MVP

### DIFF
--- a/src/components/OptionsDropdown.module.scss
+++ b/src/components/OptionsDropdown.module.scss
@@ -1,0 +1,207 @@
+.optionsDropdown {
+  ul {
+    display: grid;
+    grid-auto-flow: column dense;
+    overflow: auto;
+
+    width: 100%;
+    justify-content: flex-start;
+
+    list-style-type: none;
+
+    gap: 10px;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  @media (min-width: 901px) {
+    &.isDesktopTabs {
+      ul {
+        height: unset !important;
+        padding: 10px 0;
+        margin: -10px 0;
+      }
+
+      li {
+        margin: 10px 0;
+      }
+    }
+  }
+
+  li {
+    min-width: max-content;
+  }
+}
+
+.button {
+  border-radius: var(--b-r-l);
+}
+
+.mobileButton {
+  display: none;
+}
+
+.mobileSelected {
+  display: none;
+}
+
+.placeholder {
+  display: none;
+}
+
+.navTitle {
+  display: none;
+}
+
+@mixin dropDown($height) {
+  -webkit-tap-highlight-color: transparent;
+
+  position: relative;
+  width: fit-content;
+
+  span {
+    user-select: none;
+  }
+
+  width: fit-content;
+
+  height: $height;
+  z-index: 20;
+
+  // overflow: hidden;
+  display: grid;
+  grid-auto-flow: row dense;
+  grid-template-columns: 1fr;
+
+  transition: height 0.3s;
+
+  ul {
+    grid-auto-flow: row dense;
+    grid-template-columns: 1fr;
+    gap: 0;
+    position: absolute;
+    top: 100%;
+    width: -webkit-fill-available;
+    overflow: hidden;
+
+    border-radius: var(--b-r-l);
+    transition: height 0.3s;
+
+    background-color: var(--primary-light);
+    box-shadow: 0 0 0 1.5px var(--primary-dark);
+    margin-top: -$height;
+    padding-top: $height;
+  }
+
+  li {
+    padding: 0 20px;
+
+    display: flex;
+    align-items: center;
+
+    transition: all 0.2s;
+    position: relative;
+
+    z-index: 10;
+    top: -20px;
+    opacity: 0;
+    color: var(--primary-dark);
+
+    // box-shadow: 0 -0.5px 0 var(--primary-dark);
+
+    cursor: pointer;
+
+    &.isActive {
+      background-color: var(--primary-dark);
+      color: white;
+    }
+  }
+
+  svg {
+    font-size: 150%;
+    color: var(--primary-dark);
+    transition: transform 0.4s;
+    margin-left: 20px;
+  }
+
+  &:hover.notOpen {
+    ul {
+      box-shadow: var(--shadow-s), 0 0 0 1.5px var(--primary);
+    }
+  }
+
+  &.isOpen {
+    li {
+      top: 0;
+      opacity: 1;
+    }
+
+    ul {
+      box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.6), 0 0 0 1px var(--primary-dark);
+    }
+
+    svg {
+      transform: rotate(180deg);
+    }
+  }
+
+  .button {
+    display: none;
+  }
+  .mobileButton {
+    display: block;
+  }
+
+  .mobileSelected {
+    display: block;
+    padding: 0 20px;
+
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    z-index: 30;
+    cursor: pointer;
+  }
+
+  .titles {
+    display: grid;
+    line-height: 0;
+
+    & > * {
+      grid-column: 1;
+      grid-row: 1;
+
+      // hide if not active
+      opacity: 0;
+      color: var(--primary-dark);
+    }
+  }
+  .isTitleActive {
+    opacity: 1;
+    min-width: max-content;
+  }
+}
+
+// always do drop down on tablet except for alwaysTabs
+@media (max-width: 900px) {
+  .optionsDropdown.notAlwaysTabs {
+    @include dropDown(60px);
+  }
+}
+
+// if desktopTabs false
+@media (min-width: 901px) {
+  .notDesktopTabs.optionsDropdown.notAlwaysTabs {
+    @include dropDown(50px);
+  }
+}
+
+// @media (max-width: 600px) {
+//   .optionsDropdown {
+//     position: sticky;
+//     width: 100%;
+//     top: 70px;
+//   }
+// }

--- a/src/components/dropdown.jsx
+++ b/src/components/dropdown.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import { useState } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 // background acts as a blocker
 const BackdropStyled = styled.div`
@@ -26,13 +26,24 @@ const OptionsStyled = styled.div`
   flex-direction: column;
 
   border-radius: var(--border-radius);
-  margin: ${(props) => (props.isOpen ? '0' : '2px 0')};
-  top: ${(props) => (props.isOpen ? '-1px' : '0')};
-  /* same border used as primereact dropdowns */
-  outline: ${(props) => (props.isOpen ? '1px solid #383838;' : 'none')};
+  margin: 2px 0;
+  top: 0;
+  outline: none;
+  background-color: unset;
+  z-index: 10;
 
-  background-color: ${(props) => (props.isOpen ? 'var(--color-grey-00)' : 'unset')};
-  z-index: ${(props) => (props.isOpen ? 20 : 10)};
+  ${({ isOpen }) =>
+    isOpen &&
+    css`
+      margin: 0px;
+      top: -1px;
+      /* same border used as primereact dropdowns */
+      outline: 1px solid #383838;
+      background-color: var(--color-grey-00);
+      z-index: 20;
+      border-radius: var(--border-radius);
+      overflow: clip;
+    `}
 `
 
 const Dropdown = ({ children, onChange, value, style }) => {

--- a/src/components/dropdown.jsx
+++ b/src/components/dropdown.jsx
@@ -12,7 +12,8 @@ const BackdropStyled = styled.div`
 
 const ContainerStyled = styled.div`
   position: relative;
-  height: 100%;
+  height: ${({ height }) => `${height}px`};
+  margin-bottom: -1px;
   width: max-content;
 `
 
@@ -26,34 +27,42 @@ const OptionsStyled = styled.div`
   flex-direction: column;
 
   border-radius: var(--border-radius);
-  margin: 2px 0;
-  top: 0;
+
   outline: none;
   background-color: unset;
   z-index: 10;
+  height: ${({ height }) => `${height}px`};
 
   ${({ isOpen }) =>
     isOpen &&
     css`
       margin: 0px;
-      top: -1px;
       /* same border used as primereact dropdowns */
       outline: 1px solid #383838;
       background-color: var(--color-grey-00);
       z-index: 20;
       border-radius: var(--border-radius);
       overflow: clip;
+
+      /* calc open height based on number of options */
+      height: ${({ height, length }) => `${height * length}px`};
     `}
+
+  transition: height 0.3s;
 `
 
-const Dropdown = ({ children, onChange, value, style }) => {
+const Dropdown = ({ children, onChange, value, style, options }) => {
   const [isOpen, setIsOpen] = useState(false)
+
+  // number of options to choose from sets height for animation
+  const length = options.length
+  const closedHeight = style.height || 29
 
   return (
     <>
       {isOpen && <BackdropStyled onClick={() => setIsOpen(false)} />}
-      <ContainerStyled onClick={() => setIsOpen(!isOpen)} style={style}>
-        <OptionsStyled isOpen={isOpen} onClick={onChange}>
+      <ContainerStyled onClick={() => setIsOpen(!isOpen)} style={style} height={closedHeight}>
+        <OptionsStyled isOpen={isOpen} onClick={onChange} length={length} height={closedHeight}>
           {children({ isOpen, selected: value })}
         </OptionsStyled>
       </ContainerStyled>
@@ -62,10 +71,11 @@ const Dropdown = ({ children, onChange, value, style }) => {
 }
 
 Dropdown.propTypes = {
-  children: PropTypes.func,
+  children: PropTypes.func.isRequired,
   //   onChange: PropTypes.func.isRequired,
-  value: PropTypes.string,
+  value: PropTypes.string.isRequired,
   style: PropTypes.object,
+  options: PropTypes.array.isRequired,
 }
 
 export default Dropdown

--- a/src/components/dropdown.jsx
+++ b/src/components/dropdown.jsx
@@ -33,12 +33,6 @@ const OptionsStyled = styled.div`
 
   background-color: ${(props) => (props.isOpen ? 'var(--color-grey-00)' : 'unset')};
   z-index: ${(props) => (props.isOpen ? 20 : 10)};
-
-  /* & > * {
-    &:hover {
-      background-color: ${(props) => (props.isOpen ? 'var(--color-grey-02) !important' : 'unset')};
-    }
-  } */
 `
 
 const Dropdown = ({ children, onChange, value, style }) => {

--- a/src/components/dropdown.jsx
+++ b/src/components/dropdown.jsx
@@ -61,7 +61,14 @@ const Dropdown = ({ children, onChange, value, style, options }) => {
   return (
     <>
       {isOpen && <BackdropStyled onClick={() => setIsOpen(false)} />}
-      <ContainerStyled onClick={() => setIsOpen(!isOpen)} style={style} height={closedHeight}>
+      <ContainerStyled
+        onClick={(e) => {
+          e.stopPropagation()
+          setIsOpen(!isOpen)
+        }}
+        style={style}
+        height={closedHeight}
+      >
         <OptionsStyled isOpen={isOpen} onClick={onChange} length={length} height={closedHeight}>
           {children({ isOpen, selected: value })}
         </OptionsStyled>

--- a/src/components/dropdown.jsx
+++ b/src/components/dropdown.jsx
@@ -13,8 +13,7 @@ const BackdropStyled = styled.div`
 const ContainerStyled = styled.div`
   position: relative;
   height: ${({ height }) => `${height}px`};
-  margin-bottom: -1px;
-  width: max-content;
+  width: 100%;
 `
 
 const OptionsStyled = styled.div`

--- a/src/components/dropdown.jsx
+++ b/src/components/dropdown.jsx
@@ -26,17 +26,19 @@ const OptionsStyled = styled.div`
   flex-direction: column;
 
   border-radius: var(--border-radius);
+  margin: ${(props) => (props.isOpen ? '0' : '2px 0')};
+  top: ${(props) => (props.isOpen ? '-1px' : '0')};
   /* same border used as primereact dropdowns */
   outline: ${(props) => (props.isOpen ? '1px solid #383838;' : 'none')};
 
   background-color: ${(props) => (props.isOpen ? 'var(--color-grey-00)' : 'unset')};
   z-index: ${(props) => (props.isOpen ? 20 : 10)};
 
-  & > * {
+  /* & > * {
     &:hover {
-      background-color: ${(props) => (props.isOpen ? 'var(--color-grey-02)' : 'unset')};
+      background-color: ${(props) => (props.isOpen ? 'var(--color-grey-02) !important' : 'unset')};
     }
-  }
+  } */
 `
 
 const Dropdown = ({ children, onChange, value, style }) => {

--- a/src/components/dropdown.jsx
+++ b/src/components/dropdown.jsx
@@ -1,0 +1,64 @@
+import PropTypes from 'prop-types'
+import { useState } from 'react'
+import styled from 'styled-components'
+
+// background acts as a blocker
+const BackdropStyled = styled.div`
+  position: fixed;
+  inset: 0;
+  background-color: unset;
+  z-index: 11;
+`
+
+const ContainerStyled = styled.div`
+  position: relative;
+  height: 100%;
+  width: max-content;
+`
+
+const OptionsStyled = styled.div`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: inherit;
+
+  display: flex;
+  flex-direction: column;
+
+  border-radius: var(--border-radius);
+  /* same border used as primereact dropdowns */
+  outline: ${(props) => (props.isOpen ? '1px solid #383838;' : 'none')};
+
+  background-color: ${(props) => (props.isOpen ? 'var(--color-grey-00)' : 'unset')};
+  z-index: ${(props) => (props.isOpen ? 20 : 10)};
+
+  & > * {
+    &:hover {
+      background-color: ${(props) => (props.isOpen ? 'var(--color-grey-02)' : 'unset')};
+    }
+  }
+`
+
+const Dropdown = ({ children, onChange, value, style }) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      {isOpen && <BackdropStyled onClick={() => setIsOpen(false)} />}
+      <ContainerStyled onClick={() => setIsOpen(!isOpen)} style={style}>
+        <OptionsStyled isOpen={isOpen} onClick={onChange}>
+          {children({ isOpen, selected: value })}
+        </OptionsStyled>
+      </ContainerStyled>
+    </>
+  )
+}
+
+Dropdown.propTypes = {
+  children: PropTypes.func,
+  //   onChange: PropTypes.func.isRequired,
+  value: PropTypes.string,
+  style: PropTypes.object,
+}
+
+export default Dropdown

--- a/src/components/dropdown.jsx
+++ b/src/components/dropdown.jsx
@@ -56,7 +56,7 @@ const Dropdown = ({ children, onChange, value, style, options }) => {
 
   // number of options to choose from sets height for animation
   const length = options.length
-  const closedHeight = style.height || 29
+  const closedHeight = style.height || 27
 
   return (
     <>

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { statusSizeType } from './statusSelect'
+import { getStatusColor } from '/src/utils'
+
+const StatusField = ({ value, icon, isActive, isSelecting, size }) => {
+  const color = getStatusColor(value)
+
+  return <span style={{ color }}>{value}</span>
+}
+
+StatusField.propTypes = {
+  value: PropTypes.string.isRequired,
+  icon: PropTypes.string.isRequired,
+  isActive: PropTypes.bool,
+  isSelecting: PropTypes.bool,
+  size: statusSizeType,
+}
+
+export default StatusField

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -23,7 +23,7 @@ const moveDown = keyframes`
   }
 `
 
-const ContainerStyled = styled.div`
+const StatusStyled = styled.div`
   display: flex;
   align-items: center;
   gap: 5px;
@@ -81,6 +81,17 @@ const ContainerStyled = styled.div`
         ${invertHoverStyle}
       }
     `}
+
+  /* ALIGNMENT */
+    ${({ align }) =>
+    align === 'right' &&
+    css`
+      justify-content: end;
+
+      span {
+        order: 2;
+      }
+    `}
 `
 
 const StatusField = ({
@@ -90,23 +101,25 @@ const StatusField = ({
   isActive,
   isSelecting,
   size = 'full',
+  align = 'left',
   onClick,
   style,
 }) => {
   const color = getStatusColor(value)
 
   return (
-    <ContainerStyled
+    <StatusStyled
       style={{ ...style }}
       onClick={onClick}
       color={color}
       isActive={isActive}
       id={value}
       isSelecting={isSelecting}
+      align={align}
     >
       <span className="material-symbols-outlined">{icon}</span>
       {size !== 'icon' && (size === 'short' ? valueShort : value)}
-    </ContainerStyled>
+    </StatusStyled>
   )
 }
 
@@ -117,7 +130,9 @@ StatusField.propTypes = {
   isActive: PropTypes.bool,
   isSelecting: PropTypes.bool,
   size: PropTypes.oneOf(['full', 'short', 'icon']),
+  align: PropTypes.oneOf(['left', 'right']),
   onClick: PropTypes.func,
+  style: PropTypes.object,
 }
 
 export default StatusField

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -8,6 +8,7 @@ const ContainerStyled = styled.div`
   align-items: center;
   gap: 5px;
   font-size: var(--base-font-size);
+  border-radius: var(--border-radius);
   /* same height as a row */
   height: ${(props) => (props.isSelecting ? '29px' : '23px')};
 
@@ -15,31 +16,38 @@ const ContainerStyled = styled.div`
 
   cursor: pointer;
 
-  color: ${(props) => props.color};
-
-  :hover {
-    background-color: ${(props) =>
-      props.isSelecting ? (props.isActive ? props.color : 'var(--color-grey-02)') : props.color};
-    color: ${(props) => (props.isSelecting ? props.color : 'black')};
-
-    .material-symbols-outlined {
-      color: ${(props) => (props.isSelecting ? 'unset' : 'black')};
-    }
-  }
-
-  border-radius: var(--border-radius);
-
+  /* ICON */
   .material-symbols-outlined {
     font-variation-settings: 'FILL' 1, 'wght' 100, 'GRAD' 200, 'opsz' 20;
-    color: ${(props) => props.color};
+    /* always taks parents color */
+    color: inherit;
   }
 
-  /* when open and active set hover state */
-  background-color: ${(props) =>
-    props.isSelecting ? (props.isActive ? props.color : 'var(--color-grey-02)') : 'unset'};
-  color: ${(props) => (props.isSelecting ? (props.isActive ? 'black' : props.color) : 'unset')};
+  /* keeps the active field at the top */
+  order: 2;
+  &.isActive.isSelecting {
+    order: 1;
+  }
 
-  order: ${(props) => (props.isActive ? 0 : 1)};
+  &:not(:hover) {
+    /* text color when not hovering */
+    color: ${({ color }) => color};
+  }
+
+  /* sets for hover and when active whilst open (top one) */
+  :hover,
+  &.isActive.isSelecting {
+    /* flips the bg color for text color */
+    background-color: ${({ color }) => color};
+    color: black;
+  }
+
+  /* set hover styles for when open */
+  /* overrides hover when closed */
+  &.isSelecting.notActive:hover {
+    background-color: var(--color-grey-02);
+    color: ${({ color }) => color};
+  }
 `
 
 const StatusField = ({
@@ -62,6 +70,9 @@ const StatusField = ({
       isActive={isActive}
       id={value}
       isSelecting={isSelecting}
+      className={`${isActive ? 'isActive' : 'notActive'} ${
+        isSelecting ? 'isSelecting' : 'notSelecting'
+      }`}
     >
       <span className="material-symbols-outlined">{icon}</span>
       {size !== 'icon' && (size === 'short' ? valueShort : value)}

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -9,39 +9,69 @@ const ContainerStyled = styled.div`
   gap: 5px;
   font-size: var(--base-font-size);
   /* same height as a row */
-  height: 29px;
+  height: ${(props) => (props.isSelecting ? '29px' : '23px')};
+
+  position: relative;
+
   cursor: pointer;
+
+  color: ${(props) => props.color};
+
+  :hover {
+    background-color: ${(props) =>
+      props.isSelecting ? (props.isActive ? props.color : 'var(--color-grey-02)') : props.color};
+    color: ${(props) => (props.isSelecting ? props.color : 'black')};
+
+    .material-symbols-outlined {
+      color: ${(props) => (props.isSelecting ? 'unset' : 'black')};
+    }
+  }
+
+  border-radius: var(--border-radius);
 
   .material-symbols-outlined {
     font-variation-settings: 'FILL' 1, 'wght' 100, 'GRAD' 200, 'opsz' 20;
+    color: ${(props) => props.color};
   }
+
+  /* when open and active set hover state */
+  background-color: ${(props) =>
+    props.isSelecting ? (props.isActive ? props.color : 'var(--color-grey-02)') : 'unset'};
+  color: ${(props) => (props.isSelecting ? (props.isActive ? 'black' : props.color) : 'unset')};
 
   order: ${(props) => (props.isActive ? 0 : 1)};
 `
 
 const StatusField = ({
   value,
+  valueShort,
   icon = 'radio_button_unchecked',
   isActive,
   isSelecting,
-  size,
+  size = 'full',
   onClick,
   style,
 }) => {
   const color = getStatusColor(value)
 
   return (
-    <ContainerStyled style={{ ...style, color }} onClick={onClick} isActive={isActive} id={value}>
-      <span className="material-symbols-outlined" style={{ color }}>
-        {icon}
-      </span>
-      {value}
+    <ContainerStyled
+      style={{ ...style }}
+      onClick={onClick}
+      color={color}
+      isActive={isActive}
+      id={value}
+      isSelecting={isSelecting}
+    >
+      <span className="material-symbols-outlined">{icon}</span>
+      {size !== 'icon' && (size === 'short' ? valueShort : value)}
     </ContainerStyled>
   )
 }
 
 StatusField.propTypes = {
   value: PropTypes.string.isRequired,
+  valueShort: PropTypes.string,
   icon: PropTypes.string,
   isActive: PropTypes.bool,
   isSelecting: PropTypes.bool,

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -1,20 +1,52 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { statusSizeType } from './statusSelect'
 import { getStatusColor } from '/src/utils'
+import styled from 'styled-components'
 
-const StatusField = ({ value, icon, isActive, isSelecting, size }) => {
+const ContainerStyled = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--base-font-size);
+  /* same height as a row */
+  height: 29px;
+  cursor: pointer;
+
+  .material-symbols-outlined {
+    font-variation-settings: 'FILL' 1, 'wght' 100, 'GRAD' 200, 'opsz' 20;
+  }
+
+  order: ${(props) => (props.isActive ? 0 : 1)};
+`
+
+const StatusField = ({
+  value,
+  icon = 'radio_button_unchecked',
+  isActive,
+  isSelecting,
+  size,
+  onClick,
+  style,
+}) => {
   const color = getStatusColor(value)
 
-  return <span style={{ color }}>{value}</span>
+  return (
+    <ContainerStyled style={{ ...style, color }} onClick={onClick} isActive={isActive} id={value}>
+      <span className="material-symbols-outlined" style={{ color }}>
+        {icon}
+      </span>
+      {value}
+    </ContainerStyled>
+  )
 }
 
 StatusField.propTypes = {
   value: PropTypes.string.isRequired,
-  icon: PropTypes.string.isRequired,
+  icon: PropTypes.string,
   isActive: PropTypes.bool,
   isSelecting: PropTypes.bool,
-  size: statusSizeType,
+  size: PropTypes.oneOf(['full', 'short', 'icon']),
+  onClick: PropTypes.func,
 }
 
 export default StatusField

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -13,6 +13,11 @@ const invertHoverStyle = css`
   background-color: ${({ color }) => color};
   color: black;
 `
+const defaultStyle = css`
+  /* default text color */
+  color: ${({ color }) => color};
+  background-color: transparent;
+`
 
 const moveDown = keyframes`
   from {
@@ -43,6 +48,9 @@ const StatusStyled = styled.div`
   height: 29px;
   min-height: 29px;
 
+  ${defaultStyle}
+
+  /* selecting styles */
   ${({ isSelecting }) =>
     isSelecting &&
     css`
@@ -59,8 +67,22 @@ const StatusStyled = styled.div`
       animation-duration: 0.3s;
     `}
 
-  /* default text color */
-  color: ${({ color }) => color};
+
+    /* Only happens when a change has been made and dropdown closed */
+    ${({ isChanging, isSelecting }) =>
+    isChanging &&
+    !isSelecting &&
+    css`
+      ${invertHoverStyle}
+    `}
+
+    /* A transition animation for onChange animation */
+    ${({ isSelecting }) =>
+    !isSelecting &&
+    css`
+      transition: background-color 0.3s, color 0.3s;
+    `}
+
 
   /* sets for hover and when active whilst open (top one) */
   :hover {
@@ -98,6 +120,7 @@ const StatusField = ({
   value,
   valueShort,
   isActive,
+  isChanging,
   isSelecting,
   size = 'full',
   align = 'left',
@@ -116,6 +139,7 @@ const StatusField = ({
       id={value}
       isSelecting={isSelecting}
       align={align}
+      isChanging={isChanging}
     >
       <span className="material-symbols-outlined">{icon}</span>
       {size !== 'icon' && (size === 'short' ? valueShort : value)}
@@ -127,6 +151,7 @@ StatusField.propTypes = {
   value: PropTypes.string.isRequired,
   valueShort: PropTypes.string,
   isActive: PropTypes.bool,
+  isChanging: PropTypes.bool,
   isSelecting: PropTypes.bool,
   size: PropTypes.oneOf(['full', 'short', 'icon']),
   align: PropTypes.oneOf(['left', 'right']),

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -1,12 +1,26 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { getStatusColor } from '/src/utils'
-import styled, { css } from 'styled-components'
+import styled, { css, keyframes } from 'styled-components'
 
 const hoverStyle = css`
+  background-color: var(--color-grey-02);
+  color: ${({ color }) => color};
+`
+
+const invertHoverStyle = css`
   /* flips the bg color for text color */
   background-color: ${({ color }) => color};
   color: black;
+`
+
+const moveDown = keyframes`
+  from {
+    min-height: 18px;
+  }
+  to {
+    min-height: 29px;
+  }
 `
 
 const ContainerStyled = styled.div`
@@ -26,17 +40,32 @@ const ContainerStyled = styled.div`
 
   border-radius: var(--border-radius);
   /* same height as a row */
-  height: 23px;
+  height: 29px;
+  min-height: 29px;
 
   ${({ isSelecting }) =>
     isSelecting &&
     css`
       border-radius: 0;
       height: 29px;
+      min-height: 29px;
+    `}
+
+  ${({ isSelecting, isActive }) =>
+    isSelecting &&
+    !isActive &&
+    css`
+      animation: ${moveDown};
+      animation-duration: 0.3s;
     `}
 
   /* default text color */
   color: ${({ color }) => color};
+
+  /* sets for hover and when active whilst open (top one) */
+  :hover {
+    ${hoverStyle}
+  }
 
   /* keeps the active field at the top */
   order: 2;
@@ -46,23 +75,12 @@ const ContainerStyled = styled.div`
     css`
       /* hover always on at top */
       order: 1;
-      ${hoverStyle}
+      ${invertHoverStyle}
+
+      :hover {
+        ${invertHoverStyle}
+      }
     `}
-
-  /* sets for hover and when active whilst open (top one) */
-  :hover {
-    ${hoverStyle}
-
-    /* set hover styles for when open */
-    ${({ isActive, isSelecting }) =>
-      !isActive &&
-      isSelecting &&
-      css`
-        /* hover always on at top */
-        background-color: var(--color-grey-02);
-        color: ${({ color }) => color};
-      `}
-  }
 `
 
 const StatusField = ({

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { getStatusColor } from '/src/utils'
 import styled, { css, keyframes } from 'styled-components'
+import { getStatusIcon, getStatusColor } from '../../utils'
 
 const hoverStyle = css`
   background-color: var(--color-grey-02);
@@ -97,7 +97,6 @@ const StatusStyled = styled.div`
 const StatusField = ({
   value,
   valueShort,
-  icon = 'radio_button_unchecked',
   isActive,
   isSelecting,
   size = 'full',
@@ -106,6 +105,7 @@ const StatusField = ({
   style,
 }) => {
   const color = getStatusColor(value)
+  const icon = getStatusIcon(value)
 
   return (
     <StatusStyled
@@ -126,7 +126,6 @@ const StatusField = ({
 StatusField.propTypes = {
   value: PropTypes.string.isRequired,
   valueShort: PropTypes.string,
-  icon: PropTypes.string,
   isActive: PropTypes.bool,
   isSelecting: PropTypes.bool,
   size: PropTypes.oneOf(['full', 'short', 'icon']),

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -24,7 +24,7 @@ const moveDown = keyframes`
     min-height: 18px;
   }
   to {
-    min-height: 29px;
+    min-height: 27px;
   }
 `
 
@@ -45,8 +45,8 @@ const StatusStyled = styled.div`
 
   border-radius: var(--border-radius);
   /* same height as a row */
-  height: 29px;
-  min-height: 29px;
+  height: 27px;
+  min-height: 27px;
 
   ${defaultStyle}
 
@@ -55,8 +55,8 @@ const StatusStyled = styled.div`
     isSelecting &&
     css`
       border-radius: 0;
-      height: 29px;
-      min-height: 29px;
+      height: 27px;
+      min-height: 27px;
     `}
 
   ${({ isSelecting, isActive }) =>

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css, keyframes } from 'styled-components'
-import { getStatusIcon, getStatusColor } from '../../utils'
+import { getStatusProps } from '../../utils'
 
 const hoverStyle = css`
   background-color: var(--color-grey-02);
@@ -105,7 +105,7 @@ const StatusStyled = styled.div`
     `}
 
   /* ALIGNMENT */
-    ${({ align }) =>
+  ${({ align }) =>
     align === 'right' &&
     css`
       justify-content: end;
@@ -114,11 +114,22 @@ const StatusStyled = styled.div`
         order: 2;
       }
     `}
+
+    /* ICON ONLY STYLES */
+      ${({ size }) =>
+    size === 'icon' &&
+    css`
+      width: 100%;
+
+      span {
+        margin: auto;
+      }
+    `}
 `
 
+// RENDER
 const StatusField = ({
   value,
-  valueShort,
   isActive,
   isChanging,
   isSelecting,
@@ -127,8 +138,7 @@ const StatusField = ({
   onClick,
   style,
 }) => {
-  const color = getStatusColor(value)
-  const icon = getStatusIcon(value)
+  const { color, icon, shortName } = getStatusProps(value)
 
   return (
     <StatusStyled
@@ -140,16 +150,16 @@ const StatusField = ({
       isSelecting={isSelecting}
       align={align}
       isChanging={isChanging}
+      size={size}
     >
       <span className="material-symbols-outlined">{icon}</span>
-      {size !== 'icon' && (size === 'short' ? valueShort : value)}
+      {size !== 'icon' && (size === 'full' ? value : shortName)}
     </StatusStyled>
   )
 }
 
 StatusField.propTypes = {
   value: PropTypes.string.isRequired,
-  valueShort: PropTypes.string,
   isActive: PropTypes.bool,
   isChanging: PropTypes.bool,
   isSelecting: PropTypes.bool,

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -1,19 +1,20 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { getStatusColor } from '/src/utils'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+
+const hoverStyle = css`
+  /* flips the bg color for text color */
+  background-color: ${({ color }) => color};
+  color: black;
+`
 
 const ContainerStyled = styled.div`
   display: flex;
   align-items: center;
   gap: 5px;
   font-size: var(--base-font-size);
-  border-radius: var(--border-radius);
-  /* same height as a row */
-  height: ${(props) => (props.isSelecting ? '29px' : '23px')};
-
   position: relative;
-
   cursor: pointer;
 
   /* ICON */
@@ -23,30 +24,44 @@ const ContainerStyled = styled.div`
     color: inherit;
   }
 
+  border-radius: var(--border-radius);
+  /* same height as a row */
+  height: 23px;
+
+  ${({ isSelecting }) =>
+    isSelecting &&
+    css`
+      border-radius: 0;
+      height: 29px;
+    `}
+
+  /* default text color */
+  color: ${({ color }) => color};
+
   /* keeps the active field at the top */
   order: 2;
-  &.isActive.isSelecting {
-    order: 1;
-  }
-
-  &:not(:hover) {
-    /* text color when not hovering */
-    color: ${({ color }) => color};
-  }
+  ${({ isActive, isSelecting }) =>
+    isActive &&
+    isSelecting &&
+    css`
+      /* hover always on at top */
+      order: 1;
+      ${hoverStyle}
+    `}
 
   /* sets for hover and when active whilst open (top one) */
-  :hover,
-  &.isActive.isSelecting {
-    /* flips the bg color for text color */
-    background-color: ${({ color }) => color};
-    color: black;
-  }
+  :hover {
+    ${hoverStyle}
 
-  /* set hover styles for when open */
-  /* overrides hover when closed */
-  &.isSelecting.notActive:hover {
-    background-color: var(--color-grey-02);
-    color: ${({ color }) => color};
+    /* set hover styles for when open */
+    ${({ isActive, isSelecting }) =>
+      !isActive &&
+      isSelecting &&
+      css`
+        /* hover always on at top */
+        background-color: var(--color-grey-02);
+        color: ${({ color }) => color};
+      `}
   }
 `
 
@@ -70,9 +85,6 @@ const StatusField = ({
       isActive={isActive}
       id={value}
       isSelecting={isSelecting}
-      className={`${isActive ? 'isActive' : 'notActive'} ${
-        isSelecting ? 'isSelecting' : 'notSelecting'
-      }`}
     >
       <span className="material-symbols-outlined">{icon}</span>
       {size !== 'icon' && (size === 'short' ? valueShort : value)}

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import Dropdown from '../dropDown'
 import StatusField from './statusField'
@@ -12,7 +12,23 @@ const StatusSelect = ({
   align,
   onChange,
 }) => {
+  const [changedValue, setChangedValue] = useState(null)
+
+  useEffect(() => {
+    if (changedValue && value === changedValue) {
+      setChangedValue(null)
+    }
+  }, [value, changedValue, setChangedValue])
+
   if (!value) return null
+
+  const handleChange = (status) => {
+    if (status === value) return
+    onChange(status)
+
+    // creates a highlighted effect of new
+    setChangedValue(status)
+  }
 
   return (
     <Dropdown value={value} options={statuses} style={{ width, height }}>
@@ -25,12 +41,12 @@ const StatusSelect = ({
               size={size}
               isSelecting
               isActive={props.selected === status.name}
-              onClick={() => onChange(status.name)}
+              onClick={() => handleChange(status.name)}
               align={align}
             />
           ))
         ) : (
-          <StatusField value={value} align={align} />
+          <StatusField value={changedValue || value} align={align} isChanging={!!changedValue} />
         )
       }
     </Dropdown>

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -3,12 +3,16 @@ import PropTypes from 'prop-types'
 import Dropdown from '../dropDown'
 import StatusField from './statusField'
 
-const StatusSelect = ({ value, statuses = [], size = 'full', width = 150, height, align }) => {
+const StatusSelect = ({
+  value,
+  statuses = [],
+  size = 'full',
+  width = 150,
+  height,
+  align,
+  onChange,
+}) => {
   if (!value) return null
-
-  const handleChange = (name) => {
-    console.log(name)
-  }
 
   return (
     <Dropdown value={value} options={statuses} style={{ width, height }}>
@@ -21,7 +25,7 @@ const StatusSelect = ({ value, statuses = [], size = 'full', width = 150, height
               size={size}
               isSelecting
               isActive={props.selected === status.name}
-              onClick={() => handleChange(status.name)}
+              onClick={() => onChange(status.name)}
               align={align}
             />
           ))
@@ -44,6 +48,7 @@ StatusSelect.propTypes = {
       state: PropTypes.string.isRequired,
     }).isRequired,
   ),
+  onChange: PropTypes.func.isRequired,
 }
 
 export default StatusSelect

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Dropdown from '../dropDown'
+import StatusField from './statusField'
+
+const StatusSelect = ({ value, statuses = [], size = 'full', width = 150, height }) => {
+  if (!value) return null
+
+  const handleChange = (name) => {
+    console.log(name)
+  }
+
+  return (
+    <Dropdown value={value} style={{ width, height }}>
+      {(props) =>
+        props.isOpen ? (
+          statuses.map((status) => (
+            <StatusField
+              value={status.name}
+              key={status.name}
+              size={size}
+              isSelecting
+              isActive={props.selected === status.name}
+              onClick={() => handleChange(status.name)}
+            />
+          ))
+        ) : (
+          <StatusField value={value} />
+        )
+      }
+    </Dropdown>
+  )
+}
+
+StatusSelect.propTypes = {
+  size: PropTypes.oneOf(['full', 'short', 'icon']),
+  value: PropTypes.string,
+  statuses: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      color: PropTypes.string.isRequired,
+      state: PropTypes.string.isRequired,
+    }).isRequired,
+  ),
+}
+
+export default StatusSelect

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -7,7 +7,7 @@ const StatusSelect = ({
   value,
   statuses = [],
   size = 'full',
-  width = 150,
+  maxWidth,
   height,
   align,
   onChange,
@@ -30,8 +30,17 @@ const StatusSelect = ({
     setChangedValue(status)
   }
 
+  // calculate max width based off longest status name
+  const charWidth = 7
+  const gap = 5
+  const iconWidth = 20
+  const longestStatus = [...statuses].sort((a, b) => b.name.length - a.name.length)[0].name.length
+  const calcMaxWidth = longestStatus * charWidth + gap + iconWidth
+
+  maxWidth = maxWidth || calcMaxWidth
+
   return (
-    <Dropdown value={value} options={statuses} style={{ width, height }}>
+    <Dropdown value={value} options={statuses} style={{ maxWidth, height }}>
       {(props) =>
         props.isOpen ? (
           statuses.map((status) => (
@@ -46,7 +55,12 @@ const StatusSelect = ({
             />
           ))
         ) : (
-          <StatusField value={changedValue || value} align={align} isChanging={!!changedValue} />
+          <StatusField
+            value={changedValue || value}
+            align={align}
+            isChanging={!!changedValue}
+            size={size}
+          />
         )
       }
     </Dropdown>
@@ -65,6 +79,7 @@ StatusSelect.propTypes = {
     }).isRequired,
   ),
   onChange: PropTypes.func.isRequired,
+  maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 }
 
 export default StatusSelect

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -11,7 +11,7 @@ const StatusSelect = ({ value, statuses = [], size = 'full', width = 150, height
   }
 
   return (
-    <Dropdown value={value} style={{ width, height }}>
+    <Dropdown value={value} options={statuses} style={{ width, height }}>
       {(props) =>
         props.isOpen ? (
           statuses.map((status) => (

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Dropdown from '../dropDown'
 import StatusField from './statusField'
 
-const StatusSelect = ({ value, statuses = [], size = 'full', width = 150, height }) => {
+const StatusSelect = ({ value, statuses = [], size = 'full', width = 150, height, align }) => {
   if (!value) return null
 
   const handleChange = (name) => {
@@ -22,10 +22,11 @@ const StatusSelect = ({ value, statuses = [], size = 'full', width = 150, height
               isSelecting
               isActive={props.selected === status.name}
               onClick={() => handleChange(status.name)}
+              align={align}
             />
           ))
         ) : (
-          <StatusField value={value} />
+          <StatusField value={value} align={align} />
         )
       }
     </Dropdown>
@@ -34,6 +35,7 @@ const StatusSelect = ({ value, statuses = [], size = 'full', width = 150, height
 
 StatusSelect.propTypes = {
   size: PropTypes.oneOf(['full', 'short', 'icon']),
+  align: PropTypes.oneOf(['left', 'right']),
   value: PropTypes.string,
   statuses: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/containers/attributeTable.jsx
+++ b/src/containers/attributeTable.jsx
@@ -26,7 +26,7 @@ const AttributeTable = ({ entityType, data, additionalData, style }) => {
         additionalData.map((data, index) => (
           <AttributeTableRow key={index}>
             <span>{data.title}</span>
-            <span>{data.value}</span>
+            {data.value}
           </AttributeTableRow>
         ))}
 
@@ -36,7 +36,7 @@ const AttributeTable = ({ entityType, data, additionalData, style }) => {
           .map((attr) => (
             <AttributeTableRow key={attr.name}>
               <span>{attr.data.title}</span>
-              <span>{data[attr.name]}</span>
+              {data[attr.name]}
             </AttributeTableRow>
           ))}
     </AttributeTableContainer>

--- a/src/containers/fieldFormat.jsx
+++ b/src/containers/fieldFormat.jsx
@@ -1,8 +1,7 @@
 // Various comoonents for formatting fields in the UI
-import PropTypes from 'prop-types'
-import { getTagColor, getStatusColor } from '/src/utils'
+
+import { getTagColor } from '/src/utils'
 import styled from 'styled-components'
-import Dropdown from '../components/dropDown'
 
 // Attributes
 

--- a/src/containers/fieldFormat.jsx
+++ b/src/containers/fieldFormat.jsx
@@ -1,7 +1,8 @@
 // Various comoonents for formatting fields in the UI
-
+import PropTypes from 'prop-types'
 import { getTagColor, getStatusColor } from '/src/utils'
 import styled from 'styled-components'
+import Dropdown from '../components/dropDown'
 
 // Attributes
 
@@ -29,13 +30,6 @@ const TagsField = ({ value }) => {
       ))}
     </TagsContainer>
   )
-}
-
-// Status
-
-const StatusField = ({ value }) => {
-  if (!value) return '\u00A0'
-  return <span style={{ color: getStatusColor(value) }}>{value}</span>
 }
 
 // Datetime
@@ -90,4 +84,4 @@ const PathField = ({ value }) => {
   return <PathContainer>{value}</PathContainer>
 }
 
-export { AttributeField, TagsField, StatusField, TimestampField, PathField }
+export { AttributeField, TagsField, TimestampField, PathField }

--- a/src/pages/browser/folderDetail.jsx
+++ b/src/pages/browser/folderDetail.jsx
@@ -98,11 +98,10 @@ const FolderDetail = () => {
 
       // use operations end point to update all at once
       await axios.post(`/api/projects/${projectName}/operations`, { operations })
-      // reload data for subsets
-      // TODO: Only reload affected entities
-      // TODO: Optimistic updates will remove this manula reload
-      getFolderData()
-      // dispatch callback function to reload data
+
+      // update data state to reflect change
+      // Has wait for post request to resolve 200
+      setData({ ...data, status: value })
     } catch (error) {
       console.error(error)
     }

--- a/src/pages/browser/folderDetail.jsx
+++ b/src/pages/browser/folderDetail.jsx
@@ -123,9 +123,7 @@ const FolderDetail = () => {
           { title: 'Folder type', value: data.folderType },
           {
             title: 'Status',
-            value: (
-              <StatusSelect value={data.status} statuses={context.project.statuses} height={29} />
-            ),
+            value: <StatusSelect value={data.status} statuses={context.project.statuses} />,
           },
           { title: 'Tags', value: <TagsField value={data.tags} /> },
           { title: 'Path', value: data.path },

--- a/src/pages/browser/folderDetail.jsx
+++ b/src/pages/browser/folderDetail.jsx
@@ -123,7 +123,13 @@ const FolderDetail = () => {
           { title: 'Folder type', value: data.folderType },
           {
             title: 'Status',
-            value: <StatusSelect value={data.status} statuses={context.project.statuses} />,
+            value: (
+              <StatusSelect
+                value={data.status}
+                statuses={context.project.statuses}
+                align={'right'}
+              />
+            ),
           },
           { title: 'Tags', value: <TagsField value={data.tags} /> },
           { title: 'Path', value: data.path },

--- a/src/pages/browser/folderDetail.jsx
+++ b/src/pages/browser/folderDetail.jsx
@@ -20,6 +20,7 @@ const FOLDER_QUERY = `
             folders(ids: $folders) {
                 edges {
                     node {
+                        id
                         name
                         folderType
                         path
@@ -78,6 +79,35 @@ const FolderDetail = () => {
     })
   }
 
+  const handleStatusChange = async (value, oldValue, entity) => {
+    if (value === oldValue) return
+
+    try {
+      // create operations array of all entities
+      // currently only supports changing one status
+      const operations = [
+        {
+          type: 'update',
+          entityType: 'folder',
+          entityId: entity.id,
+          data: {
+            status: value,
+          },
+        },
+      ]
+
+      // use operations end point to update all at once
+      await axios.post(`/api/projects/${projectName}/operations`, { operations })
+      // reload data for subsets
+      // TODO: Only reload affected entities
+      // TODO: Optimistic updates will remove this manula reload
+      getFolderData()
+      // dispatch callback function to reload data
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
   // get data for folder on mount and folder change
   useEffect(() => {
     getFolderData()
@@ -128,6 +158,7 @@ const FolderDetail = () => {
                 value={data.status}
                 statuses={context.project.statuses}
                 align={'right'}
+                onChange={(v) => handleStatusChange(v, data.status, data)}
               />
             ),
           },

--- a/src/pages/browser/folderDetail.jsx
+++ b/src/pages/browser/folderDetail.jsx
@@ -12,7 +12,6 @@ import { getFolderTypeIcon } from '/src/utils'
 
 import { TagsField } from '/src/containers/fieldFormat'
 import { setReload } from '../../features/context'
-import StatusField from '../../components/status/statusField'
 import StatusSelect from '../../components/status/statusSelect'
 
 const FOLDER_QUERY = `

--- a/src/pages/browser/folderDetail.jsx
+++ b/src/pages/browser/folderDetail.jsx
@@ -13,6 +13,7 @@ import { getFolderTypeIcon } from '/src/utils'
 import { TagsField } from '/src/containers/fieldFormat'
 import { setReload } from '../../features/context'
 import StatusField from '../../components/status/statusField'
+import StatusSelect from '../../components/status/statusSelect'
 
 const FOLDER_QUERY = `
     query Folders($projectName: String!, $folders: [String!]!) {
@@ -121,7 +122,12 @@ const FolderDetail = () => {
         data={data.attrib}
         additionalData={[
           { title: 'Folder type', value: data.folderType },
-          { title: 'Status', value: <StatusField value={data.status} /> },
+          {
+            title: 'Status',
+            value: (
+              <StatusSelect value={data.status} statuses={context.project.statuses} height={29} />
+            ),
+          },
           { title: 'Tags', value: <TagsField value={data.tags} /> },
           { title: 'Path', value: data.path },
         ]}

--- a/src/pages/browser/folderDetail.jsx
+++ b/src/pages/browser/folderDetail.jsx
@@ -10,8 +10,9 @@ import Thumbnail from '/src/containers/thumbnail'
 import AttributeTable from '/src/containers/attributeTable'
 import { getFolderTypeIcon } from '/src/utils'
 
-import { StatusField, TagsField } from '/src/containers/fieldFormat'
+import { TagsField } from '/src/containers/fieldFormat'
 import { setReload } from '../../features/context'
+import StatusField from '../../components/status/statusField'
 
 const FOLDER_QUERY = `
     query Folders($projectName: String!, $folders: [String!]!) {

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -25,7 +25,7 @@ import {
 } from '/src/features/context'
 
 import { SUBSET_QUERY, parseSubsetData, VersionList } from './subsetsUtils'
-import StatusField from '../../components/status/statusField'
+import StatusSelect from '../../components/status/statusSelect'
 
 const Subsets = () => {
   const dispatch = useDispatch()
@@ -71,10 +71,13 @@ const Subsets = () => {
     {
       field: 'status',
       header: 'Status',
-      width: 100,
+      width: 150,
+      style: { overflow: 'visible', padding: '10px !important' },
       body: (node) => {
         if (node.data.isGroup) return ''
-        return <StatusField value={node.data.status} />
+        return (
+          <StatusSelect value={node.data.status} statuses={context.project.statuses} width={150} />
+        )
       },
     },
     {
@@ -287,8 +290,6 @@ const Subsets = () => {
   // Render
   //
 
-  console.log(subsetData)
-
   return (
     <Section className="wrap">
       <Toolbar>
@@ -323,12 +324,13 @@ const Subsets = () => {
             return (
               <Column
                 key={col.field}
-                style={{ width: col.width }}
+                style={{ ...col.style, width: col.width }}
                 expander={i === 0}
                 resizeable={true}
                 field={col.field}
                 header={col.header}
                 body={col.body}
+                className={col.field}
               />
             )
           })}

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -43,6 +43,9 @@ const Subsets = () => {
   const [focusOnReload, setFocusOnReload] = useState(null)
   const ctxMenuRef = useRef(null)
   const [showDetail, setShowDetail] = useState(false) // false or 'subset' or 'version'
+  // sets size of status based on status column width
+  const initStatusColumnWidth = 150
+  const [statusColumnWidth, setStatusColumnWidth] = useState(initStatusColumnWidth)
 
   // Columns definition
   // It must be here since we are referencing the component state and the context :-(
@@ -154,16 +157,24 @@ const Subsets = () => {
     {
       field: 'status',
       header: 'Status',
-      width: 150,
+      width: initStatusColumnWidth,
       style: { overflow: 'visible', padding: '10px !important', overflowX: 'clip' },
       body: (node) => {
         if (node.data.isGroup) return ''
+        const statusMaxWidth = 120
         return (
           <StatusSelect
             value={node.data.status}
             statuses={context.project.statuses}
-            width={150}
+            size={
+              statusColumnWidth < statusMaxWidth
+                ? statusColumnWidth < 60
+                  ? 'icon'
+                  : 'short'
+                : 'full'
+            }
             onChange={(v) => handleStatusChange(v, node.data.status, node.data)}
+            maxWidth="100%"
           />
         )
       },
@@ -362,6 +373,9 @@ const Subsets = () => {
           onRowClick={onRowClick}
           onContextMenu={(e) => ctxMenuRef.current?.show(e.originalEvent)}
           onContextMenuSelectionChange={onContextMenuSelectionChange}
+          onColumnResizeEnd={(e) =>
+            e.column.key === '.$status' && setStatusColumnWidth(e.element.offsetWidth)
+          }
         >
           {columns.map((col, i) => {
             return (

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -73,7 +73,6 @@ const Subsets = () => {
       })
       // successfull res
       const parsedData = parseSubsetData(response.data.data)
-      console.log(parsedData)
       return parsedData
     } catch (error) {
       console.log(error)
@@ -102,8 +101,6 @@ const Subsets = () => {
 
   // update subset status
   const handleStatusChange = async (value, oldValue, entity) => {
-    if (value === oldValue || !entity.id) return
-
     try {
       // create operations array of all entities
       // currently only supports changing one status

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -12,7 +12,7 @@ import { ContextMenu } from 'primereact/contextmenu'
 
 import EntityDetail from '/src/containers/entityDetail'
 import { CellWithIcon } from '/src/components/icons'
-import { StatusField, TimestampField } from '/src/containers/fieldFormat'
+import { TimestampField } from '/src/containers/fieldFormat'
 
 import { groupResult, getFamilyIcon } from '/src/utils'
 import {
@@ -25,6 +25,7 @@ import {
 } from '/src/features/context'
 
 import { SUBSET_QUERY, parseSubsetData, VersionList } from './subsetsUtils'
+import StatusField from '../../components/status/statusField'
 
 const Subsets = () => {
   const dispatch = useDispatch()
@@ -285,6 +286,8 @@ const Subsets = () => {
   //
   // Render
   //
+
+  console.log(subsetData)
 
   return (
     <Section className="wrap">

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -158,7 +158,7 @@ const Subsets = () => {
       field: 'status',
       header: 'Status',
       width: 150,
-      style: { overflow: 'visible', padding: '10px !important' },
+      style: { overflow: 'visible', padding: '10px !important', overflowX: 'clip' },
       body: (node) => {
         if (node.data.isGroup) return ''
         return (

--- a/src/pages/browser/subsetsUtils.jsx
+++ b/src/pages/browser/subsetsUtils.jsx
@@ -97,6 +97,7 @@ query Subsets($projectName: String!, $folders: [String!]!, $versionOverrides: [S
     }
 }
 `
+
 const parseSubsetFps = (subset) => {
   const folderFps = subset.folder.attrib.fps || ''
   if (!subset) return folderFps

--- a/src/pages/browser/taskDetail.jsx
+++ b/src/pages/browser/taskDetail.jsx
@@ -94,11 +94,10 @@ const TaskDetail = () => {
 
       // use operations end point to update all at once
       await axios.post(`/api/projects/${projectName}/operations`, { operations })
-      // reload data for subsets
-      // TODO: Only reload affected entities
-      // TODO: Optimistic updates will remove this manula reload
-      getTaskData()
-      // dispatch callback function to reload data
+
+      // update data state to reflect change
+      // Has wait for post request to resolve 200
+      setData({ ...data, status: value })
     } catch (error) {
       console.error(error)
     }

--- a/src/pages/browser/taskDetail.jsx
+++ b/src/pages/browser/taskDetail.jsx
@@ -114,7 +114,13 @@ const TaskDetail = () => {
           { title: 'Task Type', value: data.taskType },
           {
             title: 'Status',
-            value: <StatusSelect value={data.status} statuses={context.project.statuses} />,
+            value: (
+              <StatusSelect
+                value={data.status}
+                statuses={context.project.statuses}
+                align={'right'}
+              />
+            ),
           },
           { title: 'Tags', value: <TagsField value={data.tags} /> },
           {

--- a/src/pages/browser/taskDetail.jsx
+++ b/src/pages/browser/taskDetail.jsx
@@ -114,9 +114,7 @@ const TaskDetail = () => {
           { title: 'Task Type', value: data.taskType },
           {
             title: 'Status',
-            value: (
-              <StatusSelect value={data.status} statuses={context.project.statuses} height={29} />
-            ),
+            value: <StatusSelect value={data.status} statuses={context.project.statuses} />,
           },
           { title: 'Tags', value: <TagsField value={data.tags} /> },
           {

--- a/src/pages/browser/taskDetail.jsx
+++ b/src/pages/browser/taskDetail.jsx
@@ -10,6 +10,7 @@ import { TagsField } from '/src/containers/fieldFormat'
 import { Panel } from '@ynput/ayon-react-components'
 import { setReload } from '../../features/context'
 import StatusField from '../../components/status/statusField'
+import StatusSelect from '../../components/status/statusSelect'
 
 const TASK_QUERY = `
     query Tasks($projectName: String!, $tasks: [String!]!) {
@@ -112,7 +113,12 @@ const TaskDetail = () => {
         data={data.attrib}
         additionalData={[
           { title: 'Task Type', value: data.taskType },
-          { title: 'Status', value: <StatusField value={data.status} /> },
+          {
+            title: 'Status',
+            value: (
+              <StatusSelect value={data.status} statuses={context.project.statuses} height={29} />
+            ),
+          },
           { title: 'Tags', value: <TagsField value={data.tags} /> },
           {
             title: 'Assignees',

--- a/src/pages/browser/taskDetail.jsx
+++ b/src/pages/browser/taskDetail.jsx
@@ -17,6 +17,7 @@ const TASK_QUERY = `
             tasks(ids: $tasks) {
                 edges {
                     node {
+                        id
                         name
                         status
                         tags
@@ -74,6 +75,35 @@ const TaskDetail = () => {
     //eslint-disable-next-line
   }
 
+  const handleStatusChange = async (value, oldValue, entity) => {
+    if (value === oldValue) return
+
+    try {
+      // create operations array of all entities
+      // currently only supports changing one status
+      const operations = [
+        {
+          type: 'update',
+          entityType: 'task',
+          entityId: entity.id,
+          data: {
+            status: value,
+          },
+        },
+      ]
+
+      // use operations end point to update all at once
+      await axios.post(`/api/projects/${projectName}/operations`, { operations })
+      // reload data for subsets
+      // TODO: Only reload affected entities
+      // TODO: Optimistic updates will remove this manula reload
+      getTaskData()
+      // dispatch callback function to reload data
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
   useEffect(() => {
     getTaskData()
   }, [projectName, taskId])
@@ -119,6 +149,7 @@ const TaskDetail = () => {
                 value={data.status}
                 statuses={context.project.statuses}
                 align={'right'}
+                onChange={(v) => handleStatusChange(v, data.status, data)}
               />
             ),
           },

--- a/src/pages/browser/taskDetail.jsx
+++ b/src/pages/browser/taskDetail.jsx
@@ -9,7 +9,6 @@ import { getTaskTypeIcon } from '/src/utils'
 import { TagsField } from '/src/containers/fieldFormat'
 import { Panel } from '@ynput/ayon-react-components'
 import { setReload } from '../../features/context'
-import StatusField from '../../components/status/statusField'
 import StatusSelect from '../../components/status/statusSelect'
 
 const TASK_QUERY = `

--- a/src/pages/browser/taskDetail.jsx
+++ b/src/pages/browser/taskDetail.jsx
@@ -6,9 +6,10 @@ import axios from 'axios'
 
 import AttributeTable from '/src/containers/attributeTable'
 import { getTaskTypeIcon } from '/src/utils'
-import { StatusField, TagsField } from '/src/containers/fieldFormat'
+import { TagsField } from '/src/containers/fieldFormat'
 import { Panel } from '@ynput/ayon-react-components'
 import { setReload } from '../../features/context'
+import StatusField from '../../components/status/statusField'
 
 const TASK_QUERY = `
     query Tasks($projectName: String!, $tasks: [String!]!) {

--- a/src/pages/browser/versionDetail.jsx
+++ b/src/pages/browser/versionDetail.jsx
@@ -14,6 +14,7 @@ import { getFamilyIcon } from '/src/utils'
 import RepresentationList from './representationList'
 import { setReload } from '../../features/context'
 import StatusField from '../../components/status/statusField'
+import StatusSelect from '../../components/status/statusSelect'
 
 const VERSION_QUERY = `
     query Versions($projectName: String!, $versions: [String!]!) {
@@ -188,7 +189,13 @@ const VersionDetail = () => {
             { title: 'Author', value: versions[0].author },
             {
               title: 'Status',
-              value: <StatusField value={versions[0].status} />,
+              value: (
+                <StatusSelect
+                  value={versions[0].status}
+                  statuses={context.project.statuses}
+                  height={29}
+                />
+              ),
             },
             { title: 'Tags', value: <TagsField value={versions[0].tags} /> },
           ]}

--- a/src/pages/browser/versionDetail.jsx
+++ b/src/pages/browser/versionDetail.jsx
@@ -132,6 +132,35 @@ const VersionDetail = () => {
       })
   }
 
+  const handleStatusChange = async (value, oldValue, entity) => {
+    if (value === oldValue) return
+
+    try {
+      // create operations array of all entities
+      // currently only supports changing one status
+      const operations = [
+        {
+          type: 'update',
+          entityType: 'version',
+          entityId: entity.id,
+          data: {
+            status: value,
+          },
+        },
+      ]
+
+      // use operations end point to update all at once
+      await axios.post(`/api/projects/${projectName}/operations`, { operations })
+      // reload data for subsets
+      // TODO: Only reload affected entities
+      // TODO: Optimistic updates will remove this manula reload
+      getVersionData()
+      // dispatch callback function to reload data
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
   // Load versions and representations
   useEffect(() => {
     getVersionData()
@@ -193,6 +222,7 @@ const VersionDetail = () => {
                   value={versions[0].status}
                   statuses={context.project.statuses}
                   align={'right'}
+                  onChange={(v) => handleStatusChange(v, versions[0].status, versions[0])}
                 />
               ),
             },

--- a/src/pages/browser/versionDetail.jsx
+++ b/src/pages/browser/versionDetail.jsx
@@ -189,11 +189,7 @@ const VersionDetail = () => {
             {
               title: 'Status',
               value: (
-                <StatusSelect
-                  value={versions[0].status}
-                  statuses={context.project.statuses}
-                  height={29}
-                />
+                <StatusSelect value={versions[0].status} statuses={context.project.statuses} />
               ),
             },
             { title: 'Tags', value: <TagsField value={versions[0].tags} /> },

--- a/src/pages/browser/versionDetail.jsx
+++ b/src/pages/browser/versionDetail.jsx
@@ -151,11 +151,14 @@ const VersionDetail = () => {
 
       // use operations end point to update all at once
       await axios.post(`/api/projects/${projectName}/operations`, { operations })
-      // reload data for subsets
-      // TODO: Only reload affected entities
-      // TODO: Optimistic updates will remove this manula reload
-      getVersionData()
-      // dispatch callback function to reload data
+
+      // update data state to reflect change
+      // Has wait for post request to resolve 200
+      const newVersions = [...versions].map((data) =>
+        data.id === entity.id ? { ...data, status: value } : data,
+      )
+
+      setVersions(newVersions)
     } catch (error) {
       console.error(error)
     }

--- a/src/pages/browser/versionDetail.jsx
+++ b/src/pages/browser/versionDetail.jsx
@@ -13,7 +13,6 @@ import { getFamilyIcon } from '/src/utils'
 
 import RepresentationList from './representationList'
 import { setReload } from '../../features/context'
-import StatusField from '../../components/status/statusField'
 import StatusSelect from '../../components/status/statusSelect'
 
 const VERSION_QUERY = `

--- a/src/pages/browser/versionDetail.jsx
+++ b/src/pages/browser/versionDetail.jsx
@@ -189,7 +189,11 @@ const VersionDetail = () => {
             {
               title: 'Status',
               value: (
-                <StatusSelect value={versions[0].status} statuses={context.project.statuses} />
+                <StatusSelect
+                  value={versions[0].status}
+                  statuses={context.project.statuses}
+                  align={'right'}
+                />
               ),
             },
             { title: 'Tags', value: <TagsField value={versions[0].tags} /> },

--- a/src/pages/browser/versionDetail.jsx
+++ b/src/pages/browser/versionDetail.jsx
@@ -8,11 +8,12 @@ import { Panel } from '@ynput/ayon-react-components'
 
 import Thumbnail from '/src/containers/thumbnail'
 import AttributeTable from '/src/containers/attributeTable'
-import { StatusField, TagsField } from '/src/containers/fieldFormat'
+import { TagsField } from '/src/containers/fieldFormat'
 import { getFamilyIcon } from '/src/utils'
 
 import RepresentationList from './representationList'
 import { setReload } from '../../features/context'
+import StatusField from '../../components/status/statusField'
 
 const VERSION_QUERY = `
     query Versions($projectName: String!, $versions: [String!]!) {

--- a/src/pages/project.jsx
+++ b/src/pages/project.jsx
@@ -22,6 +22,7 @@ import {
   updateStatusColors,
   updateTagColors,
   updateStatusIcons,
+  updateStatusShortNames,
 } from '../utils'
 
 const ProjectContexInfo = () => {
@@ -79,6 +80,12 @@ const ProjectPage = () => {
           i[status.name] = status.icon
         }
         updateStatusIcons(i)
+
+        const n = {}
+        for (const status of data.statuses) {
+          n[status.name] = status.shortName
+        }
+        updateStatusShortNames(n)
 
         const g = {}
         for (const tag of data.tags) {

--- a/src/pages/project.jsx
+++ b/src/pages/project.jsx
@@ -21,6 +21,7 @@ import {
   updateTaskTypeIcons,
   updateStatusColors,
   updateTagColors,
+  updateStatusIcons,
 } from '../utils'
 
 const ProjectContexInfo = () => {
@@ -72,6 +73,12 @@ const ProjectPage = () => {
           t[status.name] = status.color
         }
         updateStatusColors(t)
+
+        const i = {}
+        for (const status of data.statuses) {
+          i[status.name] = status.icon
+        }
+        updateStatusIcons(i)
 
         const g = {}
         for (const tag of data.tags) {

--- a/src/styles/index.sass
+++ b/src/styles/index.sass
@@ -261,3 +261,6 @@ input:-webkit-autofill, input:-webkit-autofill:focus
 .p-treetable-scrollable-body
   flex: 1
   max-height: none !important
+
+.p-treetable td.status
+  padding: 0 !important

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,6 +103,7 @@ const loadAnatomyPresets = async () => {
 const FOLDER_TYPE_ICONS = {}
 const TASK_TYPE_ICONS = {}
 const STATUS_COLORS = {}
+const STATUS_ICONS = {}
 const TAG_COLORS = {}
 const FAMILY_ICONS = {
   image: 'imagesmode',
@@ -154,6 +155,15 @@ const updateStatusColors = (data) => {
   for (const name in data) {
     STATUS_COLORS[name] = data[name]
   }
+}
+const updateStatusIcons = (data) => {
+  for (const name in data) {
+    STATUS_ICONS[name] = data[name]
+  }
+}
+
+const getStatusIcon = (status) => {
+  return STATUS_ICONS[status] || 'radio_button_checked'
 }
 
 const getTagColor = (status) => {
@@ -235,6 +245,7 @@ export {
   getFolderTypeIcon,
   getTaskTypeIcon,
   getStatusColor,
+  getStatusIcon,
   getTagColor,
   getFamilyIcon,
   getFolderTypes,
@@ -243,6 +254,7 @@ export {
   updateFolderTypeIcons,
   updateTaskTypeIcons,
   updateStatusColors,
+  updateStatusIcons,
   updateTagColors,
   useLocalStorage,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -104,6 +104,7 @@ const FOLDER_TYPE_ICONS = {}
 const TASK_TYPE_ICONS = {}
 const STATUS_COLORS = {}
 const STATUS_ICONS = {}
+const STATUS_SHORT_NAMES = {}
 const TAG_COLORS = {}
 const FAMILY_ICONS = {
   image: 'imagesmode',
@@ -147,8 +148,12 @@ const updateTaskTypeIcons = (data) => {
   }
 }
 
-const getStatusColor = (status) => {
-  return STATUS_COLORS[status] || '#c0c0c0'
+const getStatusProps = (status) => {
+  return {
+    color: STATUS_COLORS[status] || '#c0c0c0',
+    icon: STATUS_ICONS[status] || 'radio_button_checked',
+    shortName: STATUS_SHORT_NAMES[status] || 'ERR',
+  }
 }
 
 const updateStatusColors = (data) => {
@@ -161,9 +166,10 @@ const updateStatusIcons = (data) => {
     STATUS_ICONS[name] = data[name]
   }
 }
-
-const getStatusIcon = (status) => {
-  return STATUS_ICONS[status] || 'radio_button_checked'
+const updateStatusShortNames = (data) => {
+  for (const name in data) {
+    STATUS_SHORT_NAMES[name] = data[name]
+  }
 }
 
 const getTagColor = (status) => {
@@ -244,8 +250,7 @@ export {
   sortByKey,
   getFolderTypeIcon,
   getTaskTypeIcon,
-  getStatusColor,
-  getStatusIcon,
+  getStatusProps,
   getTagColor,
   getFamilyIcon,
   getFolderTypes,
@@ -255,6 +260,7 @@ export {
   updateTaskTypeIcons,
   updateStatusColors,
   updateStatusIcons,
+  updateStatusShortNames,
   updateTagColors,
   useLocalStorage,
 }


### PR DESCRIPTION
### Brief Description

Select and change an entity status by clicking on it and selecting from a dropdown.

### Description

- `StatusSelect` and `StatusField` components reusable across the app.
- New `OptionsDropdown` dropdown that's agnostic and reusable.
- `onChange` handlers post data and then reload data automatically.
- `StatusField` has `alignment` and `size` props.
- Uses pure CSS for all styling effects to optimise speed.
- Status reflects changes instantly (before db request has resolved).
- Status has a nice highlighted to fading off effect to emphasise a change.
- `StatusSelect` `size` changes based on status column size.
- Width is calculated using length of longest status.

![status_select_v003](https://user-images.githubusercontent.com/49156310/209951867-2075fcd4-1b87-4fd9-ad49-2a443ae93b9f.gif)

### TODO

- Icons default to circle when not found (API needs updating).
- If two of the same status are shown in different areas of the app, the none selected status won't auto update (RTK Query should fix).
- Multiselect (change multiple ones at once).

### Testing

- Click on any status and a dropdown should appear with all status options
- Clicking a new status should hide the dropdown and the original status should change.
- Try making the Status column bigger and smaller, `StatusSelect` should adapt to size.